### PR TITLE
feat: TitoBits v2 Phase 3 (Contact capture mode)

### DIFF
--- a/astro-web/src/lib/tito/handoff.ts
+++ b/astro-web/src/lib/tito/handoff.ts
@@ -80,3 +80,35 @@ export async function enviarNotificacion(lead: LeadData) {
     console.warn("Falta RESEND_API_KEY. Notificación por correo (Resend) omitida. Google Chat fue invocado si su key existe.");
   }
 }
+
+// Constante de fallback — hardcodeada, no generada por LLM
+export const FALLBACK_CONTACTO = `Sin problema. Puedes contactarnos directamente:
+• Correo: info@taec.com.mx
+• WhatsApp: https://api.whatsapp.com/send/?phone=5215527758279`;
+
+// Extrae nombre, empresa y email de un mensaje de texto libre
+export function extraerContacto(message: string): {
+  nombre: string | null,
+  empresa: string | null,
+  email: string | null
+} {
+  const emailRegex = /([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9._-]+)/;
+  const emailMatch = message.match(emailRegex);
+  const email = emailMatch ? emailMatch[0] : null;
+
+  // Simple heuristic for name and company if explicit like "Soy Ana López de Grupo Bimbo"
+  let nombre = null;
+  let empresa = null;
+
+  const soyMatch = message.match(/soy\s+([^,.]+)(?:,|\s+de\s+|\s+en\s+|$)/i);
+  if (soyMatch && soyMatch[1]) {
+    nombre = soyMatch[1].trim();
+  }
+
+  const deMatch = message.match(/(?:de|en)\s+([A-Z][a-zA-Z0-9\s]+)(?:,|\.|@|$)/);
+  if (deMatch && deMatch[1]) {
+    empresa = deMatch[1].trim();
+  }
+
+  return { nombre, empresa, email };
+}

--- a/astro-web/src/pages/api/tito-chat.ts
+++ b/astro-web/src/pages/api/tito-chat.ts
@@ -13,13 +13,74 @@ import type { APIRoute } from 'astro';
 import { getSystemRulesString, evaluateMessageForEscalation } from '../../lib/tito/rules';
 import { getEmbedding, searchSimilarChunks, supabase } from '../../lib/tito/rag';
 import { calcularScore, determinarHandoff, type LeadSignals } from '../../lib/tito/scoring';
-import { generarMiniBrief, enviarNotificacion } from '../../lib/tito/handoff';
+import { generarMiniBrief, enviarNotificacion, extraerContacto, FALLBACK_CONTACTO } from '../../lib/tito/handoff';
 
 export const POST: APIRoute = async ({ request }) => {
   try {
     const body = await request.json();
     const message = body.message || '';
     const sessionId = body.session_id || 'anonymous-session';
+
+    // ======= FASE 3: MODO CAPTURA =======
+    const { data: existingLead } = await supabase
+      .from('tito_leads')
+      .select('*')
+      .eq('session_id', sessionId)
+      .single();
+
+    if (existingLead && existingLead.awaiting_contact) {
+      const contacto = extraerContacto(message);
+      
+      const isRefusal = message.toLowerCase().match(/(no quiero|no te dar|no gracias)/) !== null;
+      const hasDatos = contacto.nombre || contacto.empresa || contacto.email;
+
+      if (isRefusal || !hasDatos) {
+        return new Response(JSON.stringify({
+          reply: FALLBACK_CONTACTO,
+          handoff_tipo: existingLead.handoff_tipo,
+          score: existingLead.score
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+
+      let awaitingContactUpdate = false;
+      let replyCapture = `Listo ${contacto.nombre || existingLead.nombre || ''}, nuestro equipo te contacta en menos de 24 horas hábiles.`.trim();
+
+      // Regla: Si el usuario da solo email sin nombre -> aceptarlo, preguntar nombre en siguiente turno
+      if (contacto.email && !contacto.nombre && !existingLead.nombre) {
+        awaitingContactUpdate = true;
+        replyCapture = "Gracias por tu correo. ¿Me podrías indicar tu nombre, por favor?";
+      }
+
+      const mergedNombre = contacto.nombre || existingLead.nombre;
+      const mergedEmail = contacto.email || existingLead.email;
+      const mergedEmpresa = contacto.empresa || existingLead.empresa;
+
+      const { data: updatedLead, error: leadUpdateError } = await supabase.from('tito_leads').update({
+        nombre: mergedNombre,
+        empresa: mergedEmpresa,
+        email: mergedEmail,
+        awaiting_contact: awaitingContactUpdate
+      }).eq('id', existingLead.id).select().single();
+
+      if (!awaitingContactUpdate && !leadUpdateError && updatedLead) {
+        enviarNotificacion({
+          id: updatedLead.id,
+          session_id: sessionId,
+          email: updatedLead.email,
+          nombre: updatedLead.nombre,
+          empresa: updatedLead.empresa,
+          score: updatedLead.score,
+          minibrief: updatedLead.minibrief,
+          handoff_tipo: updatedLead.handoff_tipo as 'ventas' | 'preventa_tecnica'
+        });
+      }
+
+      return new Response(JSON.stringify({
+        reply: replyCapture,
+        handoff_tipo: existingLead.handoff_tipo,
+        score: existingLead.score
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
 
     // ======= MOTOR 1: EVALUAR REGLAS Y TRIGGERS =======
     const rulesContext = getSystemRulesString();
@@ -62,27 +123,16 @@ export const POST: APIRoute = async ({ request }) => {
           minibrief: miniBrief,
           handoff_tipo: handoffTipo,
           handoff_triggered: true,
-          email: null // Placeholder para info real, se recolectará en Fase 3
+          email: null,
+          awaiting_contact: true // Fase 3: Set to true when handoff triggers
         }
       ], { onConflict: 'session_id' }).select().single();
 
-      if (!leadError && leadData) {
-        // Enviar Webhook/Resend de manera aislada y no bloqueante
-        enviarNotificacion({
-          id: leadData.id,
-          session_id: sessionId,
-          email: leadData.email,
-          nombre: leadData.nombre,
-          empresa: leadData.empresa,
-          score: leadData.score,
-          minibrief: leadData.minibrief,
-          handoff_tipo: leadData.handoff_tipo as 'ventas' | 'preventa_tecnica'
-        });
-      } else {
+      if (leadError || !leadData) {
         console.error("Fallo persistiendo a Supabase tito_leads:", leadError);
       }
 
-      reply = "He notificado preventivamente a nuestro equipo sobre tu requerimiento avanzado. Te contactarán a la brevedad.";
+      reply = "Para conectarte con el especialista correcto, ¿me confirmas tu nombre, empresa y correo corporativo?";
     } else if (escalationCheck === 'INFORM') {
       reply = "Por favor indícame la cantidad exacta de licencias o alcances para asistirte.";
     } else {

--- a/astro-web/src/pages/api/tito-chat.ts
+++ b/astro-web/src/pages/api/tito-chat.ts
@@ -43,7 +43,10 @@ export const POST: APIRoute = async ({ request }) => {
       }
 
       let awaitingContactUpdate = false;
-      let replyCapture = `Listo ${contacto.nombre || existingLead.nombre || ''}, nuestro equipo te contacta en menos de 24 horas hábiles.`.trim();
+      const nombreFinal = contacto.nombre || existingLead.nombre;
+      let replyCapture = nombreFinal
+        ? `Listo ${nombreFinal}, nuestro equipo te contacta en menos de 24 horas hábiles.`
+        : `Listo, nuestro equipo te contacta en menos de 24 horas hábiles.`;
 
       // Regla: Si el usuario da solo email sin nombre -> aceptarlo, preguntar nombre en siguiente turno
       if (contacto.email && !contacto.nombre && !existingLead.nombre) {


### PR DESCRIPTION
## Descripción
Implementación de la **Fase 3: Modo Captura de TitoBits v2**.
Esta PR interrumpe el flujo normal del Lead cuando el motor detona un *Handoff*. En su lugar de notificar asíncronamente y no recolectar contacto directo, ahora intercepta la sesión.

### Cambios realizados
* **Supabase (+ Migración DDL):** Se añadió el boolean de estado `awaiting_contact` (default *false*) a la tabla `tito_leads`.
* **`handoff.ts`:**
  * Implementado algoritmo base `extraerContacto()` (Regex y Heurísticas) para recolectar dinámicamente Nombre, Empresa y Email de manera unificada basándose en inputs crudos.
  * Agregada constante estática `FALLBACK_CONTACTO` como salvaguarda ante *refusals* de contacto.
* **`tito-chat.ts`:**
  * El motor de *routing* evalúa `awaiting_contact` al inicio del `POST`.
  * Si detecta intención de escalado previa y el usuario se comunica formalmente con datos de contacto, interrumpe flujos a RAG y LLM resolviendo la extracción.
  * Si carece momentáneamente de nombre (solo provee correo), almacena el *state* intermedio del lead continuando la sub-petición pero actualizando el _lead_.
  * Posteriormente, notifica internamente solo la primera vez que se resuelve por fin la captura.

### Validaciones
- [x] Schema actualizado vía migración
- [x] Reglas respetadas `titoKnowledgeBase.ts`, `promos.ts` inmutables.
- [x] Pruebas de subida a repositorio con Git rules.