### PR TITLE
feat(tito): implementación del job de indexación RAG

### DIFF
--- a/astro-web/scripts/test-retrieval.ts
+++ b/astro-web/scripts/test-retrieval.ts
@@ -1,0 +1,77 @@
+import * as dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+// Load .env from project root
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+dotenv.config({ path: resolve(__dirname, '../.env') });
+
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.PUBLIC_SUPABASE_ANON_KEY;
+process.env.TAEC_GEMINI_KEY = ""; // Force mock embeddings
+
+import { getEmbedding, searchSimilarChunks } from '../src/lib/tito/rag.js';
+
+const BATERIA_PRUEBAS = [
+  "¿Cuánto cuesta Storyline 360 y qué incluye?",
+  "Necesito traducir un curso a portugués automáticamente, ¿Reach 360 puede hacerlo?",
+  "¿Vyond permite exportar a SCORM?",
+  "Quiero comprar Articulate 360 para mi equipo de 5 personas. ¿Hay descuentos?",
+  "¿Cuál es la diferencia principal entre Storyline 360 y Rise 360?",
+  "Mi empresa necesita facturar en México con CFDI. ¿Puedo obtener factura de Vyond?",
+  "¿Reach 360 incluye cursos prehechos, o solo sirve para LMS?",
+  "¿Cuánto cuesta el plan Teams de Articulate y qué ventajas tiene sobre el Personal?",
+  "Ya tenemos LMS corporativo, ¿se puede integrar Reach 360 con nuestro LMS, o es por separado?",
+  "¿Puedo probar Vyond gratis sin meter mi tarjeta de crédito?"
+];
+
+async function runTests() {
+  console.log("=========================================");
+  console.log(" BATERÍA DE PRUEBAS DE RETRIEVAL (TITO)  ");
+  console.log("=========================================");
+
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    console.error("❌ Faltan variables de entorno. Asegúrate de tener SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY.");
+    return;
+  }
+
+  let pasadas = 0;
+
+  for (let i = 0; i < BATERIA_PRUEBAS.length; i++) {
+    const q = BATERIA_PRUEBAS[i];
+    console.log(`\n\n📝 Q${i + 1}: "${q}"`);
+    console.log("-----------------------------------------");
+    
+    try {
+      const embedding = await getEmbedding(q);
+      const chunks = await searchSimilarChunks(embedding, 0.4, 3);
+      
+      if (!chunks || chunks.length === 0) {
+        console.log("❌ SIN RESULTADOS (Threshold muy alto o indexación vacía)");
+        continue;
+      }
+      
+      pasadas++;
+      chunks.forEach((c: any, idx: number) => {
+        const metadata = c.metadata || {};
+        console.log(`[Top ${idx + 1}] SIMILITUD: ${(c.similarity * 100).toFixed(1)}%`);
+        console.log(`> Fuente: ${metadata.source_url} | Sección: ${metadata.section_title} | Intención: ${metadata.intent_hint}`);
+        if(c.content.length > 200) {
+            console.log(`> Extracto: ${c.content.substring(0, 200).replace(/\\n/g, ' ')}...`);
+        } else {
+            console.log(`> Extracto: ${c.content.replace(/\\n/g, ' ')}`);
+        }
+        
+      });
+    } catch (e: any) {
+      console.error("❌ Error en la prueba:", e.message);
+    }
+  }
+
+  console.log("\n=========================================");
+  console.log(` FIN DE LA PRUEBA - Con Resultados: ${pasadas}/${BATERIA_PRUEBAS.length}`);
+  console.log("=========================================");
+}
+
+runTests();

--- a/astro-web/scripts/trigger-index.ts
+++ b/astro-web/scripts/trigger-index.ts
@@ -1,0 +1,36 @@
+import * as dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+dotenv.config({ path: resolve(__dirname, '../.env') });
+
+// Setup globals before import
+process.env.SITE_URL = 'http://localhost:4322';
+process.env.SITE_URL = 'http://localhost:4322';
+process.env.TITO_INDEX_SECRET = process.env.TITO_INDEX_SECRET || 'localtest';
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.PUBLIC_SUPABASE_ANON_KEY;
+process.env.TAEC_GEMINI_KEY = ""; // Force mock embeddings
+
+async function run() {
+  console.log("Triggering Index API...");
+
+  const { GET } = await import('../src/pages/api/tito-index.ts');
+  const fakeRequest = new Request('http://localhost/api/tito-index', {
+    headers: {
+      'authorization': `Bearer ${process.env.TITO_INDEX_SECRET}`
+    }
+  });
+
+  try {
+    const res = await GET({ request: fakeRequest } as any);
+    const json = await res.json();
+    console.log("Result:", json);
+  } catch (e) {
+    console.error("Error executing index trigger", e);
+  }
+}
+
+run();

--- a/astro-web/src/pages/api/tito-index.ts
+++ b/astro-web/src/pages/api/tito-index.ts
@@ -1,0 +1,150 @@
+import type { APIRoute } from "astro";
+import { RAG_SOURCES } from "../../lib/tito/rules";
+import { getEmbedding, supabase } from "../../lib/tito/rag";
+
+/**
+ * Helper to split text into overlapping chunks
+ */
+function chunkText(text: string, maxWords = 500, overlapWords = 50): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const chunks: string[] = [];
+  let i = 0;
+  
+  if (words.length === 0) return chunks;
+
+  while (i < words.length) {
+    const chunkWords = words.slice(i, i + maxWords);
+    chunks.push(chunkWords.join(' '));
+    if (i + maxWords >= words.length) break;
+    i += maxWords - overlapWords;
+  }
+  return chunks;
+}
+
+/**
+ * Basic HTML text extractor
+ */
+function extractTextFromHtml(html: string): string {
+  // Extract body
+  const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  let content = bodyMatch ? bodyMatch[1] : html;
+  
+  // Strip out irrelevant tags
+  content = content.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, ' ');
+  content = content.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, ' ');
+  content = content.replace(/<nav\b[^<]*(?:(?!<\/nav>)<[^<]*)*<\/nav>/gi, ' ');
+  content = content.replace(/<header\b[^<]*(?:(?!<\/header>)<[^<]*)*<\/header>/gi, ' ');
+  content = content.replace(/<footer\b[^<]*(?:(?!<\/footer>)<[^<]*)*<\/footer>/gi, ' ');
+  content = content.replace(/<svg\b[^<]*(?:(?!<\/svg>)<[^<]*)*<\/svg>/gi, ' ');
+
+  // Prioritize <main> or <article> if available
+  const mainMatch = content.match(/<main[^>]*>([\s\S]*?)<\/main>/i) || content.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  if (mainMatch) {
+    content = mainMatch[1];
+  }
+
+  // Strip all HTML tags
+  let text = content.replace(/<[^>]+>/g, ' ');
+  
+  // Normalize whitespace & entities
+  text = text.replace(/&nbsp;/ig, ' ')
+             .replace(/&amp;/ig, '&')
+             .replace(/&#39;/g, "'")
+             .replace(/&quot;/ig, '"');
+             
+  text = text.replace(/\s+/g, ' ').trim();
+  
+  return text;
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const authHeader = request.headers.get('authorization');
+  const secret = import.meta.env.TITO_INDEX_SECRET || process.env.TITO_INDEX_SECRET;
+  
+  if (!secret || authHeader !== `Bearer ${secret}`) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { 
+      status: 401, 
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  const siteUrl = import.meta.env.SITE_URL || process.env.SITE_URL;
+  if (!siteUrl) {
+    return new Response(JSON.stringify({ error: "SITE_URL no configurada" }), { 
+      status: 500, 
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+
+  let indexedCount = 0;
+  let totalChunks = 0;
+  const errors: string[] = [];
+
+  for (const source of RAG_SOURCES) {
+    try {
+      const pageUrl = `${siteUrl.replace(/\/$/, '')}${source}`;
+      const response = await fetch(pageUrl);
+      
+      if (!response.ok) {
+        errors.push(`Error fetching ${pageUrl}: ${response.statusText}`);
+        continue;
+      }
+
+      const html = await response.text();
+      const text = extractTextFromHtml(html);
+      const chunks = chunkText(text, 500, 50);
+
+      // Obtener chunks existentes para este source_url
+      const { data: existingChunks, error: dbError } = await supabase
+        .from('tito_knowledge_chunks')
+        .select('id, content')
+        .eq('source_url', source);
+
+      if (dbError) {
+        errors.push(`Error consultando BD para ${source}: ${dbError.message}`);
+        continue;
+      }
+
+      const existing = existingChunks || [];
+
+      for (const chunk of chunks) {
+        // Idempotencia: Verificar por las primeras 100 letras del contenido
+        const prefix = chunk.substring(0, 100);
+        const existingChunk = existing.find(e => e.content.startsWith(prefix));
+
+        const embedding = await getEmbedding(chunk);
+
+        if (existingChunk) {
+          // Atualizar
+          await supabase.from('tito_knowledge_chunks').update({
+            content: chunk,
+            embedding: embedding,
+            updated_at: new Date().toISOString()
+          }).eq('id', existingChunk.id);
+        } else {
+          // Insertar
+          await supabase.from('tito_knowledge_chunks').insert({
+            source_url: source,
+            content: chunk,
+            embedding: embedding
+          });
+        }
+        totalChunks++;
+      }
+      
+      indexedCount++;
+
+    } catch (err: any) {
+      errors.push(`Excepción procesando ${source}: ${err.message}`);
+    }
+  }
+
+  return new Response(JSON.stringify({
+    indexed: indexedCount,
+    chunks_total: totalChunks,
+    errors: errors.length > 0 ? errors : undefined
+  }), { 
+    status: 200, 
+    headers: { 'Content-Type': 'application/json' }
+  });
+};


### PR DESCRIPTION
## Descripción

Se ha añadido un endpoint de indexación (`src/pages/api/tito-index.ts`) para alimentar la base de chunks de TitoBits v2.

### Cambios realizados:
1. Endpoint `GET` protegido mediante autenticación con header (`Bearer TITO_INDEX_SECRET`).
2. Iteración dinámica sobre `RAG_SOURCES`.
3. Lógica de web scraping y limpieza del payload HTML extrayendo solo texto de `<main>` o `<body>`.
4. Segmentación en chunks de 500 palabras con overlapping de 50.
5. Invocación de `getEmbedding()` (de Gemini text-embedding-004) por cada chunk y escritura "idempotente" sobre `tito_knowledge_chunks` a través de chequeo sintáctico de las primeras 100 letras.
6. Respuesta JSON controlada y reporte en array para registrar aciertos y fallos a nivel endpoint.

### Notas importantes
* Configurar `TITO_INDEX_SECRET` y `SITE_URL` en Netlify antes de poner activo en producción.