### PR TITLE
fix(chat): support CRLF chunk splitting for SSE streaming edge payload drop

### DIFF
--- a/astro-web/src/components/chat/ChatAgent.tsx
+++ b/astro-web/src/components/chat/ChatAgent.tsx
@@ -378,7 +378,7 @@ export default function ChatAgent({ isApp = false, userName = '' }: { isApp?: bo
           break;
         }
         chunkData += decoder.decode(value, { stream: true });
-        const parts = chunkData.split('\n\n');
+        const parts = chunkData.split(/\r?\n\r?\n/);
         chunkData = parts.pop() || "";
         
         for (const part of parts) {
@@ -528,7 +528,7 @@ export default function ChatAgent({ isApp = false, userName = '' }: { isApp?: bo
          }
          
          chunkData += decoder.decode(value, { stream: true });
-         const parts = chunkData.split('\n\n');
+         const parts = chunkData.split(/\r?\n\r?\n/);
          chunkData = parts.pop() || "";
          
          for (const part of parts) {


### PR DESCRIPTION
### Objetivo
Solucionar un defecto crítico donde Tito Bits omitía por completo los tokens del LLM en el entorno de producción (Netlify), resultando en mensajes completamente en blanco.

### Causa Raíz
El parser del frontend en `ChatAgent.tsx` estaba rígidamente esperando fragmentos separados por `\n\n`. Sin embargo, tras desplegar el backend en las Serverless Edge Functions de Netlify, los eventos de servidor (SSE) pasaron a enviarse con saltos de línea estándar de red `\r\n\r\n`. Esto provocaba que `split('\n\n')` fallara por completo en el navegador.

### Solución
Se ha factorizado la lógica de segmentación de flujos en las funciones `sendMessage` y `sendExpandMessage` para emplear la expresión regular universal `/\r?\n\r?\n/`, previniendo la eliminación silenciosa de la respuesta cuando viaja mediante un proxy o entorno V8 estricto.