### PR TITLE
feat(titobits): apply v3 coherency fixes for diagnostic

### DIFF
--- a/astro-web/src/components/Header.astro
+++ b/astro-web/src/components/Header.astro
@@ -87,7 +87,7 @@ import { r, base } from '../utils/paths';
                     {col.title && <span class="mega-head">{col.title}</span>}
                     {col.items.map((link) => {
                       if (link.isDivider) return <div class="mega-divider"></div>;
-                      return <a href={r(link.url)} role="menuitem">{link.label}</a>;
+                      return <a href={r(link.url)} role="menuitem" data-astro-reload={link.url.includes('reset=1') ? true : undefined}>{link.label}</a>;
                     })}
                     {col.bottomLink && (
                       <a href={r(col.bottomLink.url)} role="menuitem" style="color:var(--blue);font-weight:600;margin-top:4px">{col.bottomLink.label}</a>
@@ -102,7 +102,7 @@ import { r, base } from '../utils/paths';
     </nav>
     <div class="header-actions">
       <a href={contactData.storeUrl} target="_blank" rel="noopener noreferrer" class="btn-tienda">Tienda</a>
-      <a href={r('/diagnostico')} class="btn-cta">Diagnóstico IA →</a>
+      <a href={r('/diagnostico?reset=1')} class="btn-cta" data-astro-reload>Diagnóstico IA →</a>
     </div>
     <button class="hamburger" id="menuBtn" aria-label="Abrir menú">
       <span></span><span></span><span></span>

--- a/astro-web/src/components/chat/ChatAgent.tsx
+++ b/astro-web/src/components/chat/ChatAgent.tsx
@@ -192,15 +192,14 @@ export default function ChatAgent({ isApp = false, userName = '' }: { isApp?: bo
       isOpenStore.set(true);
       hasUnreadMessagesStore.set(false);
       
-      // Inyectamos el contexto como si fuera un mensaje del usuario (invisible) 
-      // y la primera respuesta de TitoBits (visible).
-      messagesStore.set([
-        { role: 'user', text: `[SYSTEM_HIDDEN_CONTEXT]\n${prompt}\n[/SYSTEM_HIDDEN_CONTEXT]` },
-        { 
-          role: 'agent', 
-          text: `¡Hola ${aliasName}! Soy Tito Bits, Partner IA de TAEC. Acabo de procesar tu Diagnóstico y evaluar tus resultados para **${diagnosticResult}**.\n\nHe leído en las respuestas anteriores los retos específicos que tienes en tu operación. Como siguiente paso, ¿podrías confirmarme aproximadamente cuántos usuarios (empleados/clientes) usarían la plataforma en el primer año para poder dimensionar la arquitectura?` 
-        }
-      ]);
+      // Inyectamos el contexto vía sendMessage para que el LLM genere el saludo con rol Challenger.
+      // Así evitamos hardcodear el saludo y romper la metodología.
+      const userMessage = `[SYSTEM_HIDDEN_CONTEXT]\n${prompt}\n[/SYSTEM_HIDDEN_CONTEXT]\n\n¡Hola Tito! Acabo de terminar mi diagnóstico. Por favor analiza mis resultados y dime qué opinas.`;
+      
+      // Delay minúsculo para permitir que React cambie hasStarted a true antes del send
+      setTimeout(() => {
+        sendMessage(undefined, userMessage);
+      }, 50);
     };
 
     window.addEventListener('OpenTitoDiagnostic', handleDiagnosticContext);
@@ -442,12 +441,12 @@ export default function ChatAgent({ isApp = false, userName = '' }: { isApp?: bo
     }
   };
 
-  const sendMessage = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!input.trim() || isLoading) return;
+  const sendMessage = async (e?: React.FormEvent, overrideText?: string) => {
+    if (e) e.preventDefault();
+    const userMsg = overrideText || input.trim();
+    if (!userMsg || isLoading) return;
 
-    const userMsg = input.trim();
-    setInput('');
+    if (!overrideText) setInput('');
 
     const gibberishCheck = gibberishGuard(userMsg);
     if (gibberishCheck.isGibberish) {

--- a/astro-web/src/pages/api/agente-ia.ts
+++ b/astro-web/src/pages/api/agente-ia.ts
@@ -109,8 +109,10 @@ export const POST: APIRoute = async ({ request, locals }) => {
         }));
     }
 
+    const isDiagnostic = typeof currentPath === 'string' && currentPath.toLowerCase().includes('diagnostico');
+
     // ======= 1. INTEGRACIÓN TITO-CHAT (SCORING Y HANDOFF) =======
-    if (sessionId !== 'anonymous-session') {
+    if (sessionId !== 'anonymous-session' && !isDiagnostic) {
       const { data: existingLead } = await supabase
         .from('tito_leads')
         .select('*')
@@ -352,11 +354,13 @@ de contacto, responde EXACTAMENTE esto (sin modificar):
 
 No agregues nada más. No sigas intentando capturar datos.
 
-REGLAS DE CONVERSIÓN B2B (CAPTURA DE LEADS):
-- CÓMO PEDIR DATOS: Si el prospecto entra por la web general, dile: "Por favor, escribe aquí mismo en el chat tu correo corporativo...". PERO si el prospecto viene del DIAGNÓSTICO (ya leíste su correo en el sistema), JAMÁS LE VUELVAS A PEDIR EL CORREO O TELÉFONO. 
+${!isDiagnostic ? `REGLAS DE CONVERSIÓN B2B (CAPTURA DE LEADS):
+- CÓMO PEDIR DATOS: Si el prospecto entra por la web general, dile: "Por favor, escribe aquí mismo en el chat tu correo corporativo...".
 - CONFIRMACIÓN: Al recibir datos, confírmalos explícitamente: *"¡Excelente! He registrado tus datos de forma segura."*
 - CANDADO ANTI-BUCLE INFALIBLE: Si notas que estás dando vueltas en círculo realizando las mismas preguntas, O si el usuario te responde con que ya te dio la respuesta, O si te responde agresivamente/harto, TIENES ESTRICTAMENTE PROHIBIDO volver a preguntar. Debes dar el chat por CASI CONCLUIDO diciendo: *"Entendido perfectamente. Con esta información ya tengo el panorama completo de tu caso. Un especialista humano analizará esto y te contactará a la brevedad con la ruta exacta. ¿Queda alguna otra duda técnica que pueda resolver por ti hoy?"*
-- REGLA ANTI-REPETICIÓN ESTRICTA: Si el usuario te responde dándote un dato personal (nombre, email, empresa) en lugar de responder a tus preguntas técnicas, TIENES TOTALMENTE PROHIBIDO volver a imprimirle la misma lista de preguntas (bullet points) que le enviaste en el mensaje anterior. Simplemente confirma la recepción de sus datos y haz solo UNA pregunta conversacional corta para retomar la plática o asume el escenario para avanzar y darle una recomendación. No seas un robot insistente.
+- REGLA ANTI-REPETICIÓN ESTRICTA: Si el usuario te responde dándote un dato personal (nombre, email, empresa) en lugar de responder a tus preguntas técnicas, TIENES TOTALMENTE PROHIBIDO volver a imprimirle la misma lista de preguntas (bullet points) que le enviaste en el mensaje anterior. Simplemente confirma la recepción de sus datos y haz solo UNA pregunta conversacional corta para retomar la plática o asume el escenario para avanzar y darle una recomendación. No seas un robot insistente.` : `REGLAS DE CONTINUIDAD DIAGNÓSTICO (CHALLENGER):
+- MANTÉN LA PERSISTENCIA CONSULTIVA: NUNCA utilices respuestas enlatadas de finalización como "un especialista humano analizará esto". ERES el Consultor. 
+- SI EL USUARIO RESPONDE CORTO (ej. "es todo" o "no"): En lugar de cerrar el chat, reta al usuario amigablemente sobre su radiografía ("Entiendo, solo recuerda que tu falta de integración actual podría causar un cuello de botella con esos 1500 usuarios. ¿Han considerado cómo mitigar esto?"). Mantén el framework Challenger vivo.`}
 
 ==================================================
 BASE DE CONOCIMIENTO CENTRALIZADA (CEREBRO B2B):


### PR DESCRIPTION
Fixes aplicados para el sprint de diagnóstico (V3):

1. **Handoff Logic**: `agente-ia.ts` ahora captura el `isDiagnostic` antes de las rutinas de escalamiento de ventas genérico, asegurando que el flow no pregunte por contactos ni se reduzca si el score >= 50.
2. **Contexto Challenger**: Reemplazado el Candado Anti-Bucle (que despedía prematuramente diciendo que "un especialista se pondrá en contacto") por las **REGLAS DE CONTINUIDAD DIAGNÓSTICO (CHALLENGER)**, forzando a Tito Bits a ser persistente y profundizar en las dudas en lugar de escaparse si el usuario da respuestas cortas.
3. **Reset de Navegación**: Agregado `data-astro-reload` al `Header.astro` para el enlace de *Diagnóstico IA* forzando un hard-reload para que los React Islands y el *sessionStorage* se resetien correctamente al picarle en el NavBar.