### PR TITLE
fix(agente-ia): corregir lógica de turnos para diagnóstico challenger vs B2B conversión

### DIFF
--- a/astro-web/src/pages/api/agente-ia.ts
+++ b/astro-web/src/pages/api/agente-ia.ts
@@ -110,6 +110,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
 
     const isDiagnostic = typeof currentPath === 'string' && currentPath.toLowerCase().includes('diagnostico');
+    const isFirstDiagnosticTurn = isDiagnostic && safeHistory.length === 0;
     // ======= 1. INTEGRACIÓN TITO-CHAT (SCORING Y HANDOFF) =======
     if (sessionId !== 'anonymous-session' && !isDiagnostic) {
       const { data: existingLead } = await supabase
@@ -302,7 +303,7 @@ Solo pide datos de contacto cuando:
 → Volumen 100+ seats
 → Cliente pregunta por renovación o contrato existente
 
-${isDiagnostic 
+${isFirstDiagnosticTurn 
   ? `REGLA DE CONSULTORÍA DIAGNÓSTICO (ESTADO ACTUAL):
 El prospecto ya viene del motor de diagnóstico y ya tenemos sus datos.
 TU OBJETIVO ES CONTINUAR COMO CONSULTOR EXPERTO TÉCNICO.


### PR DESCRIPTION
Corrige el bug reciente donde el modo Challenger Continuity de Diagnóstico era ignorado a partir del turno 2 y reemplazado erróneamente por las reglas normales de Conversión B2B.

A partir de ahora, solo el primer turno de diagnóstico invoca las instrucciones estáticas introductorias de "Estado Actual", y todo el diálogo subsecuente delega correctamente a Challenger Continuity (sin inyectar la captura forzada B2B estándar).