### PR TITLE
fix(ui): reach 360 nav dropdown z-index overlap in hero section #21

### DIFF
--- a/astro-web/public/assets/css/art-pricing.css
+++ b/astro-web/public/assets/css/art-pricing.css
@@ -6,8 +6,8 @@
 .art-tab.active{color:var(--art);border-bottom-color:var(--art)}
 
 /* ── hero ── */
-.art-hero{background:linear-gradient(135deg, #050E14 0%, #0B3347 45%, #13668D 100%);padding:72px 5% 80px}
-.art-hero-inner{max-width:1100px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:56px;align-items:center}
+.art-hero{background:linear-gradient(135deg, #050E14 0%, #0B3347 45%, #13668D 100%);padding:72px 5% 80px;position:relative;z-index:10}
+.art-hero-inner{max-width:1100px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:56px;align-items:center;position:relative;z-index:11}
 .art-logo-pill{display:inline-flex;background:white;border-radius:10px;padding:10px 20px;margin-bottom:20px;box-shadow:0 2px 14px rgba(0,0,0,.2)}
 .art-logo-pill img{height:34px;width:auto}
 .art-logo-badge{display:inline-flex;align-items:center;justify-content:center;width:56px;height:56px;border-radius:50%;background:rgba(255,255,255,.15);border:2px solid rgba(255,255,255,.3);font-size:16px;font-weight:800;color:white;margin-bottom:20px;font-family:'Inter',sans-serif}


### PR DESCRIPTION
### Fix: Reach 360 Dropdown Z-Index Visual Bug

This PR addresses **[ISSUE-021]** affecting the `/articulate-reach` page. 
The CSS mockup in the hero section was causing a partial stacking context overlap in some browsers (e.g., Safari), which resulted in the header dropdown (`.mega-menu`) visually breaking or rendering behind parts of the hero.

**Changes:**
- Added explicit `position: relative;` and `z-index: 10;` to `.art-hero` in `art-pricing.css`.
- Secured the explicit safe-stacking depth context so it won't conflict with the `header` which is structurally `z-index: 999999` and `position: sticky`. 

Please request Claude Code to audit the changes as per the TAEC git workflow guidelines.