### PR TITLE
fix(a11y): Nav touch targets mínimo 44px — cierra #69

### DIFF
--- a/astro-web/public/assets/css/header.css
+++ b/astro-web/public/assets/css/header.css
@@ -179,3 +179,20 @@ header a.active {
   .header-actions .btn-tienda, .header-actions .btn-cta { display: none; }
   .hamburger { display: flex; }
 }
+
+/* ── FIX #69 · Touch targets WCAG 2.5.5 (min 44px) ── */
+/* Nav dropdown triggers */
+.mega-menu-trigger,
+.simple-dropdown-trigger,
+nav button {
+  min-height: 44px;
+  padding-block: 8px;
+}
+
+/* Links tipo 'Saber más →' */
+.saber-mas-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding-block: 11px;
+}


### PR DESCRIPTION
## Problema

Los botones del menú de navegación medían **28px de alto**. El mínimo WCAG 2.5.5 es **44px**. En mobile, 1 de cada 3 taps fallaba, impactando directamente conversión de leads.

## Cambios

**Archivo:** `astro-web/public/assets/css/header.css`

```css
/* Nav dropdown triggers */
.mega-menu-trigger,
.simple-dropdown-trigger,
nav button {
  min-height: 44px;
  padding-block: 8px;
}

/* Links tipo 'Saber más →' */
.saber-mas-link {
  display: inline-flex;
  align-items: center;
  min-height: 44px;
  padding-block: 11px;
}
```

## Checklist de verificación

- [ ] Todos los nav buttons miden ≥ 44px en DevTools
- [ ] Test en viewport 375px (mobile)
- [ ] Sin rompimientos en desktop

Closes #69