### PR TITLE
fix(design): FINDING-004 — Reemplazar patrón genérico de iconos-en-círculos

### DIFF
--- a/astro-web/public/assets/css/index.css
+++ b/astro-web/public/assets/css/index.css
@@ -84,7 +84,7 @@
 .servicios { padding: 72px 5%; background: var(--light); }
 .servicios-inner { max-width: 1200px; margin: 0 auto; }
 .servicios-list { display: flex; flex-direction: column; gap: 0; border-top: 1px solid var(--border); margin-top: 40px; }
-.serv-row { display: grid; grid-template-columns: 1fr 2fr; gap: 40px; padding: 40px 0; border-bottom: 1px solid var(--border); transition: background-color .3s; align-items: start; border-radius: 14px; }
+.serv-row { display: grid; grid-template-columns: 1fr 2fr; gap: 40px; padding: 40px 0; border-bottom: 1px solid var(--border); transition: background-color .3s; align-items: start; }
 .serv-row:hover { background-color: var(--light); }
 .serv-row-left h3 { font-family: var(--font-display); font-size: 24px; color: var(--navy); line-height: 1.25; }
 .serv-row-right p { font-size: 16px; color: var(--muted); margin-bottom: 16px; line-height: 1.6; }
@@ -223,9 +223,6 @@
   .section-head { flex-direction: column; align-items: flex-start; gap: 8px; }
 }
 
-@media (max-width: 480px) {
-  .hero h1 { font-size: 26px; }
-}
 
 /* ── ACCESIBILIDAD ── */
 @media (prefers-reduced-motion: reduce) {

--- a/astro-web/public/assets/css/index.css
+++ b/astro-web/public/assets/css/index.css
@@ -83,16 +83,12 @@
 /* ── SERVICIOS ── */
 .servicios { padding: 72px 5%; background: var(--light); }
 .servicios-inner { max-width: 1200px; margin: 0 auto; }
-.servicios-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 18px; }
-.serv-card { background: var(--white); border: 1px solid var(--border); border-radius: 14px; padding: 26px 22px; transition: box-shadow .3s ease, transform .3s ease, background-color .3s ease; display: flex; flex-direction: column; }
-.serv-card:hover { background-color: #004775; box-shadow: 0 8px 28px rgba(0,71,117,.1); transform: translateY(-3px); }
-.serv-icon { width: 48px; height: 48px; border-radius: 12px; background: linear-gradient(135deg, rgba(168,219,217,.3), rgba(49,121,194,.15)); display: flex; align-items: center; justify-content: center; font-size: 22px; margin-bottom: 16px; flex-shrink: 0; }
-.serv-card h3 { font-size: 16px; font-weight: 700; color: var(--navy); margin-bottom: 8px; line-height: 1.3; transition: color .3s ease; }
-.serv-card:hover h3 { color: var(--white); }
-.serv-card p { font-size: 13px; color: var(--muted); line-height: 1.65; flex: 1; transition: color .3s ease; }
-.serv-card:hover p { color: #E2E8F0; }
-.serv-link { display: inline-flex; align-items: center; gap: 4px; margin-top: 16px; font-size: 14px; font-weight: 700; color: var(--blue); letter-spacing: .2px; transition: color .15s, gap .15s; }
-.serv-card:hover .serv-link { color: var(--teal); }
+.servicios-list { display: flex; flex-direction: column; gap: 0; border-top: 1px solid var(--border); margin-top: 40px; }
+.serv-row { display: grid; grid-template-columns: 1fr 2fr; gap: 40px; padding: 40px 0; border-bottom: 1px solid var(--border); transition: background-color .3s; align-items: start; border-radius: 14px; }
+.serv-row:hover { background-color: var(--light); }
+.serv-row-left h3 { font-family: var(--font-display); font-size: 24px; color: var(--navy); line-height: 1.25; }
+.serv-row-right p { font-size: 16px; color: var(--muted); margin-bottom: 16px; line-height: 1.6; }
+.serv-link { display: inline-flex; align-items: center; gap: 4px; font-size: 14px; font-weight: 700; color: var(--blue); letter-spacing: .2px; transition: color .15s, gap .15s; }
 .serv-link:hover { color: var(--navy); gap: 8px; }
 
 /* ── CÓMO TRABAJAMOS ── */
@@ -104,6 +100,8 @@
 .paso:hover { background-color: #004775; transform: translateY(-3px); }
 .paso-num { width: 56px; height: 56px; border-radius: 50%; background: var(--white); border: 2px solid var(--teal); display: flex; align-items: center; justify-content: center; font-family: var(--font-display); font-size: 20px; color: var(--blue); margin-bottom: 20px; flex-shrink: 0; position: relative; transition: background .3s, border-color .3s, color .3s; }
 .paso:hover .paso-num { background: var(--teal); border-color: var(--teal); color: var(--white); }
+.step-number { font-family: var(--font-display); font-size: 3rem; color: var(--blue); opacity: 0.35; line-height: 1; margin-bottom: 16px; transition: opacity .3s, color .3s; }
+.paso:hover .step-number { color: var(--teal); opacity: 0.8; }
 .paso h3 { font-size: 16px; font-weight: 700; color: var(--navy); margin-bottom: 8px; transition: color .3s ease; }
 .paso:hover h3 { color: var(--white); }
 .paso p  { font-size: 13px; color: var(--muted); line-height: 1.6; transition: color .3s ease; }
@@ -203,7 +201,7 @@
 
 /* ── RESPONSIVE EXCLUSIVO HOME ── */
 @media (max-width: 1024px) {
-  .servicios-grid { grid-template-columns: repeat(3, 1fr); }
+  .serv-row { gap: 24px; }
   .pasos-grid { grid-template-columns: repeat(2, 1fr); gap: 32px; }
   .pasos-grid::before { display: none; }
   /* footer grid is managed in footer.css */
@@ -215,7 +213,7 @@
   .hero-sub { font-size: 15px; }
   .hero-tag { white-space: normal; }
   .stat-grid { grid-template-columns: 1fr 1fr; }
-  .servicios-grid { grid-template-columns: 1fr 1fr; }
+  .serv-row { grid-template-columns: 1fr; gap: 16px; padding: 32px 0; }
   .pasos-grid { grid-template-columns: 1fr; gap: 24px; }
   .testi-card { flex: 0 0 280px; }
   .recursos-grid { grid-template-columns: 1fr; }
@@ -226,7 +224,7 @@
 }
 
 @media (max-width: 480px) {
-  .servicios-grid { grid-template-columns: 1fr; }
+  .hero h1 { font-size: 26px; }
 }
 
 /* ── ACCESIBILIDAD ── */

--- a/astro-web/src/pages/index.astro
+++ b/astro-web/src/pages/index.astro
@@ -219,36 +219,51 @@ if (activePromos.length > 0) {
           </div>
           <a href={r('/soluciones')} class="see-all">Ver todas las soluciones <span class="arrow-icon">→</span></a>
         </div>
-        <div class="servicios-grid">
-          <div class="serv-card reveal-up">
-            <div class="serv-icon">🛠️</div>
-            <h3>Herramientas de autoría</h3>
-            <p>Articulate 360, Vyond y más. Licencias oficiales con soporte en español, factura mexicana y precio en pesos al tipo de cambio del día.</p>
-            <a href={r('/articulate-360-mexico')} class="serv-link">Ver herramientas <span class="arrow-icon">→</span></a>
+        <div class="servicios-list">
+          <div class="serv-row reveal-up">
+            <div class="serv-row-left">
+              <h3>Herramientas de autoría</h3>
+            </div>
+            <div class="serv-row-right">
+              <p>Articulate 360, Vyond y más. Licencias oficiales con soporte en español, factura mexicana y precio en pesos al tipo de cambio del día.</p>
+              <a href={r('/articulate-360-mexico')} class="serv-link">Ver herramientas <span class="arrow-icon">→</span></a>
+            </div>
           </div>
-          <div class="serv-card">
-            <div class="serv-icon">🎬</div>
-            <h3>Desarrollo de cursos a medida</h3>
-            <p>Diseño instruccional + producción en Articulate o Vyond. E-learning, microlearning, blended learning y MOOCs listos para tu LMS.</p>
-            <a href={r('/desarrollo-de-contenidos')} class="serv-link">Ver proceso →</a>
+          <div class="serv-row">
+            <div class="serv-row-left">
+              <h3>Desarrollo de cursos a medida</h3>
+            </div>
+            <div class="serv-row-right">
+              <p>Diseño instruccional + producción en Articulate o Vyond. E-learning, microlearning, blended learning y MOOCs listos para tu LMS.</p>
+              <a href={r('/desarrollo-de-contenidos')} class="serv-link">Ver proceso →</a>
+            </div>
           </div>
-          <div class="serv-card">
-            <div class="serv-icon">⚙️</div>
-            <h3>Implementación LMS</h3>
-            <p>Moodle, Totara, Articulate Reach y más. Instalación, configuración, migración de contenidos y capacitación a tu equipo.</p>
-            <a href={r('/moodle-mexico')} class="serv-link">Ver plataformas →</a>
+          <div class="serv-row">
+            <div class="serv-row-left">
+              <h3>Implementación LMS</h3>
+            </div>
+            <div class="serv-row-right">
+              <p>Moodle, Totara, Articulate Reach y más. Instalación, configuración, migración de contenidos y capacitación a tu equipo.</p>
+              <a href={r('/moodle-mexico')} class="serv-link">Ver plataformas →</a>
+            </div>
           </div>
-          <div class="serv-card">
-            <div class="serv-icon">💡</div>
-            <h3>Consultoría L&D</h3>
-            <p>Diagnóstico de brechas, estrategia de capacitación, analítica de aprendizaje y acompañamiento de adopción con metodología probada.</p>
-            <a href={r('/nosotros')} class="serv-link">Saber más →</a>
+          <div class="serv-row">
+            <div class="serv-row-left">
+              <h3>Consultoría L&D</h3>
+            </div>
+            <div class="serv-row-right">
+              <p>Diagnóstico de brechas, estrategia de capacitación, analítica de aprendizaje y acompañamiento de adopción con metodología probada.</p>
+              <a href={r('/nosotros')} class="serv-link">Saber más →</a>
+            </div>
           </div>
-          <div class="serv-card">
-            <div class="serv-icon">📋</div>
-            <h3>Evaluaciones de alta seguridad</h3>
-            <p>Plataforma especializada en exámenes de alta importancia. Diseño y análisis de evaluaciones con estándares para certificación.</p>
-            <a href={r('/contacto')} class="serv-link">Ver más →</a>
+          <div class="serv-row">
+            <div class="serv-row-left">
+              <h3>Evaluaciones de alta seguridad</h3>
+            </div>
+            <div class="serv-row-right">
+              <p>Plataforma especializada en exámenes de alta importancia. Diseño y análisis de evaluaciones con estándares para certificación.</p>
+              <a href={r('/contacto')} class="serv-link">Ver más →</a>
+            </div>
           </div>
         </div>
       </div>
@@ -264,22 +279,22 @@ if (activePromos.length > 0) {
         </div>
         <div class="pasos-grid">
           <div class="paso">
-            <div class="paso-num">1</div>
+            <span class="step-number">01</span>
             <h3>Diagnóstico</h3>
             <p>Analizamos tus necesidades reales de capacitación, presupuesto, infraestructura y equipo — no el ideal teórico.</p>
           </div>
           <div class="paso">
-            <div class="paso-num">2</div>
+            <span class="step-number">02</span>
             <h3>Recomendación</h3>
             <p>Proponemos la solución que funciona para tu contexto específico. No la más cara ni la más popular — la correcta.</p>
           </div>
           <div class="paso">
-            <div class="paso-num">3</div>
+            <span class="step-number">03</span>
             <h3>Implementación</h3>
             <p>Entregamos, configuramos y capacitamos a tu equipo hasta que dominen las herramientas. En español, desde CDMX.</p>
           </div>
           <div class="paso">
-            <div class="paso-num">4</div>
+            <span class="step-number">04</span>
             <h3>Acompañamiento</h3>
             <p>Soporte continuo post-implementación. Estamos cuando nos necesitas, no solo en la venta.</p>
           </div>


### PR DESCRIPTION
Fixes #72

### Changes Made:
- Removed the generic tool/icon card layout from the Soluciones section, shifting to an editorial list row (`.servicios-list`).
- Replaced the colored circles with icons in the "Cómo trabajamos contigo" process section with a typographical numbering approach (`.step-number`) prioritizing the \`var(--font-display)\` and setting opacity to \`0.35\` as requested.
- Hover states properly aligned with the overarching brand (using \`var(--light)\`).
- Safely removed `.serv-card` formatting and fully transitioned emojis out.

Ready for QA / Review.