### PR TITLE
fix(typography): unificar headers de sección en articulate-360-mexico (#70)

### DIFF
--- a/astro-web/src/pages/articulate-360-mexico.astro
+++ b/astro-web/src/pages/articulate-360-mexico.astro
@@ -115,7 +115,6 @@ const faqsArt = [
     .g2-section { background: #F8FAFC; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); padding: 48px 5%; }
     .g2-inner { max-width: 960px; margin: 0 auto; }
     .g2-header { text-align: center; margin-bottom: 32px; }
-    .g2-header h2 { font-size: 22px; font-weight: 700; color: #111827; margin-bottom: 6px; }
     .g2-header p { font-size: 14px; color: #64748B; }
     .g2-row { display: flex; align-items: center; gap: 48px; flex-wrap: wrap; justify-content: center; }
     .g2-badge { display: flex; flex-direction: column; align-items: center; gap: 4px; min-width: 120px; }
@@ -323,7 +322,7 @@ const faqsArt = [
 <section style="background:var(--navy);padding:56px 5%;">
   <div style="max-width:1200px;margin:0 auto;">
     <p style="font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:var(--teal);margin-bottom:8px;">Proceso de compra</p>
-    <h2 style="font-family:var(--font-display);font-size:28px;color:var(--white);margin-bottom:40px;">Tu cuenta activa en 24 horas</h2>
+    <h2 class="section-title" style="color:var(--white);margin-bottom:40px;">Tu cuenta activa en 24 horas</h2>
     <div class="pasos-grid" style="display:grid;grid-template-columns:repeat(4,1fr);gap:24px;">
       <div style="text-align:center;">
         <div style="width:52px;height:52px;border-radius:50%;background:var(--orange);color:var(--white);font-size:20px;font-weight:800;display:flex;align-items:center;justify-content:center;margin:0 auto 16px;">1</div>
@@ -489,7 +488,7 @@ const faqsArt = [
 <section style="background:var(--light);padding:64px 5%;">
   <div style="max-width:900px;margin:0 auto;">
     <p style="font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:var(--blue);margin-bottom:8px;">Resultado real</p>
-    <h2 style="font-family:var(--font-display);font-size:28px;color:var(--navy);margin-bottom:40px;">Lo que logran nuestros clientes con Articulate 360</h2>
+    <h2 class="section-title" style="margin-bottom:40px;">Lo que logran nuestros clientes con Articulate 360</h2>
     <div class="caso-grid" style="background:var(--white);border:1px solid var(--border);border-radius:16px;padding:36px;display:grid;grid-template-columns:1fr 1fr;gap:40px;align-items:center;">
       <div>
         <div style="display:flex;gap:16px;margin-bottom:20px;">
@@ -530,7 +529,7 @@ const faqsArt = [
 <section class="g2-section">
   <div class="g2-inner">
     <div class="g2-header">
-      <h2>Lo que dicen los usuarios en G2</h2>
+      <h2 class="section-title">Lo que dicen los usuarios en G2</h2>
       <p>Reseñas verificadas de profesionales de e-learning en todo el mundo</p>
     </div>
     <div class="g2-row">


### PR DESCRIPTION
Resolves #70

### Qué se ajustó
- Todos los componentes de etiquetas `<h2>` en el archivo `articulate-360-mexico.astro` fueron transicionados al uso de la clase global `.section-title` ya incorporada en `index.css`.
- Se previnieron conflictos de CSS anulando anidaciones sueltas que modificaran el weight y tamaño localmente (ej: `.g2-header h2`). La jerarquía permanece sumamente limpia.
- No existían etiquetas `<h2>` de *TitoBits* en el scope de esta página, por lo tanto, no requerimos converger a `<p>`.

### Verificación
- [x] El Type checker (`tsc --noEmit`) terminó arrojando resultado exitoso (0 exit code).
- [x] Tamaño de tags unificado vía clamp & design system garantizado.

Asignado para QA/Merge final.