### PR TITLE
fix(chat): Migrate T7 redirect to Astro View Transitions

### DIFF
--- a/astro-web/src/components/chat/ChatAgent.tsx
+++ b/astro-web/src/components/chat/ChatAgent.tsx
@@ -1,6 +1,7 @@
 import { useStore } from "@nanostores/react";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { navigate } from "astro:transitions/client";
 import { chatCategoryRules } from "../../data/chatContextRules";
 import { safeRenderMarkdown } from "../../lib/tito/sanitizer";
 import { gibberishGuard, trackTitoEvent } from "../../lib/tito/titoAnalytics";
@@ -573,7 +574,7 @@ export default function ChatAgent({
 		if (!overrideText) setInput("");
 
 		if (userMsg.toUpperCase().includes("MODO DIAGNOSTICO")) {
-			window.location.href = "/diagnostico";
+			navigate("/diagnostico");
 			return;
 		}
 


### PR DESCRIPTION
### Propósito del PR

Resuelve OBS-2 reportada en el Issue #91. 
Se reemplazó la redirección estática (`window.location.href`) por `navigate` de `"astro:transitions/client"` para el modo diagnóstico (`T7`). Esto previene que se rompan las animaciones SPA de View Transitions.

_NOTA: Este PR tiene como base la rama `fix/qa-regression-v3.5.0` ya que sobre ella se trabajó el cambio lógico._