### PR TITLE
fix: Claude PR Auditor — agregar permiso pull-requests: write al workflow

### DIFF
--- a/.github/workflows/pr-claude-auditor.yml
+++ b/.github/workflows/pr-claude-auditor.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   audit-diff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #95

Agrega el bloque `permissions` necesario con `pull-requests: write` para que el script `github.rest.issues.createComment` pueda postear el veredicto en el Pull Request.