### PR TITLE
fix(vendors): URL trial Articulate con UTM directo

### DIFF
--- a/astro-web/src/data/vendors.ts
+++ b/astro-web/src/data/vendors.ts
@@ -3,6 +3,6 @@ export const vendors = {
 		signup: "https://think.vyond.com/signup",
 	},
 	articulate: {
-		trial: "https://articulate.com/es/360/trial/",
+		trial: "https://www.articulate.com/es/360/trial/?utm_source=em_partner&utm_medium=referral&utm_campaign=a360|-|04-03-2026&utm_content=empartnersdirectreferral",
 	},
 };


### PR DESCRIPTION
## Problema

La URL anterior usaba un wrapper de Gmail (`google.com/url?source=gmail`) que perdía los parámetros UTM al llegar a Articulate — confirmado en prueba de red.

## Solución

Reemplazar por la URL directa con los UTM correctos:

```
https://www.articulate.com/es/360/trial/?utm_source=em_partner&utm_medium=referral&utm_campaign=a360|-|04-03-2026&utm_content=empartnersdirectreferral
```

## Impacto

Los 14 botones "Prueba gratis" que consumen `vendors.articulate.trial` quedan correctamente atribuidos a TAEC en el GA4 de Articulate.