### PR TITLE
feat(titobits): personality modes switchable via Supabase

### DIFF
--- a/astro-web/src/lib/tito/personality.ts
+++ b/astro-web/src/lib/tito/personality.ts
@@ -1,0 +1,29 @@
+export type PersonalityMode = 'breve' | 'medio' | 'bavardo'
+
+export const PERSONALITY_MODIFIERS: Record<PersonalityMode, string> = {
+  breve: `
+MODO DE RESPUESTA: BREVE
+- Máximo 2 oraciones por respuesta.
+- Sin emojis, sin listas, sin saludos extra.
+- Solo hechos y la siguiente acción concreta.
+- Si no tienes la info exacta, di: "Eso lo resuelve un especialista TAEC. ¿Te contactamos?"`,
+
+  medio: `
+MODO DE RESPUESTA: MEDIO
+- Respuestas de 2 a 4 oraciones.
+- Puedes usar una lista corta cuando enumeres características.
+- Tono directo y profesional, sin emojis.
+- Cierra con una pregunta de avance cuando sea natural.`,
+
+  bavardo: `
+MODO DE RESPUESTA: CONSULTIVO
+- Respuestas conversacionales de hasta 6 oraciones.
+- Muestra autoridad técnica: compara categorías, da ejemplos de uso real.
+- Puedes usar emojis con moderación (máximo 1 por respuesta).
+- Haz preguntas de discovery para entender el contexto del cliente.
+- Anticipa objeciones y ofrece contexto antes de que lo pidan.`,
+}
+
+export function getPersonalityModifier(mode: PersonalityMode): string {
+  return PERSONALITY_MODIFIERS[mode] ?? PERSONALITY_MODIFIERS['medio']
+}

--- a/astro-web/src/pages/api/tito-chat.ts
+++ b/astro-web/src/pages/api/tito-chat.ts
@@ -31,12 +31,27 @@ import {
 	determinarHandoff,
 	type LeadSignals,
 } from "../../lib/tito/scoring";
+import { getPersonalityModifier, type PersonalityMode } from '../../lib/tito/personality';
 
 export const POST: APIRoute = async ({ request }) => {
 	try {
 		const body = await request.json();
 		const message = body.message || "";
 		const sessionId = body.session_id || "anonymous-session";
+
+		// Fetch personality mode from Supabase config (non-blocking, default 'medio')
+		let personalityMode: PersonalityMode = 'medio';
+		try {
+			const { data: config } = await supabase
+				.from('tito_config')
+				.select('mode')
+				.eq('id', 1)
+				.single();
+			if (config?.mode) personalityMode = config.mode as PersonalityMode;
+		} catch {
+			// keep default
+		}
+		const personalityModifier = getPersonalityModifier(personalityMode);
 
 		// ======= FASE 3: MODO CAPTURA =======
 		const { data: existingLead } = await supabase
@@ -246,10 +261,11 @@ Resuelves preguntas sobre productos e-learning (Articulate 360, Vyond, Moodle, T
 REGLAS:
 ${rulesContext}
 
+${personalityModifier}
+
 CONTEXTO DE LA BASE DE CONOCIMIENTO:
 ${ragContext || "No se encontró contexto relevante."}
 
-Responde al siguiente mensaje del usuario de forma concisa, directa y sin emojis.
 Si no tienes la información precisa en el contexto, transfiere a ventas.
 
 Usuario: ${message}

--- a/astro-web/src/pages/api/tito-chat.ts
+++ b/astro-web/src/pages/api/tito-chat.ts
@@ -39,20 +39,6 @@ export const POST: APIRoute = async ({ request }) => {
 		const message = body.message || "";
 		const sessionId = body.session_id || "anonymous-session";
 
-		// Fetch personality mode from Supabase config (non-blocking, default 'medio')
-		let personalityMode: PersonalityMode = 'medio';
-		try {
-			const { data: config } = await supabase
-				.from('tito_config')
-				.select('mode')
-				.eq('id', 1)
-				.single();
-			if (config?.mode) personalityMode = config.mode as PersonalityMode;
-		} catch {
-			// keep default
-		}
-		const personalityModifier = getPersonalityModifier(personalityMode);
-
 		// ======= FASE 3: MODO CAPTURA =======
 		const { data: existingLead } = await supabase
 			.from("tito_leads")
@@ -253,6 +239,20 @@ Schema esperado:
 		} else {
 			// CONTINUE — responder con Gemini usando contexto RAG
 			const ragContext = contextChunks.map((c: any) => c.content).join("\n\n");
+
+			// Fetch personality mode from Supabase config (non-blocking, default 'medio')
+			let personalityMode: PersonalityMode = 'medio';
+			try {
+				const { data: config } = await supabase
+					.from('tito_config')
+					.select('mode')
+					.eq('id', 1)
+					.single();
+				if (config?.mode) personalityMode = config.mode as PersonalityMode;
+			} catch {
+				// keep default
+			}
+			const personalityModifier = getPersonalityModifier(personalityMode);
 
 			const conversationPrompt = `
 Eres TitoBits, el asistente comercial de TAEC — empresa líder en tecnología de aprendizaje corporativo en México y LATAM.


### PR DESCRIPTION
Resolves #102. Adds personality modes switchable via Supabase config without redeploy. Features added:
- `tito_config` table on Supabase.
- `personality.ts` holding different modifier prompts.
- Updated `tito-chat.ts` to actively pull config and switch the context personality.
Awaiting Claude Code QA.