### PR TITLE
feat(clientes): implementar página /clientes y colores de marca en ticker (#107, #108)

### DIFF
--- a/astro-web/public/assets/css/index.css
+++ b/astro-web/public/assets/css/index.css
@@ -134,6 +134,12 @@
 .cliente-logo-pill:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(0,0,0,.25); }
 .cliente-logo-pill img { height: 28px; width: auto; max-width: 100px; object-fit: contain; display: block; }
 .cliente-logo-pill span { font-size: 13px; font-weight: 800; color: #111827; letter-spacing: .3px; white-space: nowrap; }
+.cliente-logo-pill.brand-gs1 span       { color: #003DA5; }
+.cliente-logo-pill.brand-viva span      { color: #FF5A00; }
+.cliente-logo-pill.brand-unicef span    { color: #00AEEF; }
+.cliente-logo-pill.brand-oim span       { color: #009FE3; }
+.cliente-logo-pill.brand-penoles span   { color: #003366; }
+.cliente-logo-pill.brand-tec span       { color: #003865; }
 
 /* ── RECURSOS ── */
 .recursos { padding: 72px 5%; background: var(--white); }

--- a/astro-web/src/pages/clientes.astro
+++ b/astro-web/src/pages/clientes.astro
@@ -3,6 +3,65 @@ import { contactData } from "../data/contact";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 import { r } from "../utils/paths";
+
+const testimonios = [
+  {
+    org: "OIM Perú",
+    industria: "Organización Internacional",
+    iniciales: "OI",
+    quote:
+      "Los cursos que se desarrollaron han cumplido con toda su funcionalidad. La colaboración y productividad nos han dejado satisfechos. Esperamos poder seguir trabajando con TAEC en el futuro.",
+  },
+  {
+    org: "UNICEF Costa Rica",
+    industria: "Organización Internacional",
+    iniciales: "UN",
+    quote:
+      "Articulate es de gran apoyo para gestionar los cursos en línea de nuestras contrapartes y lograr nuestros objetivos. TAEC otorga un gran apoyo y servicio gracias a su cercana colaboración y disponibilidad de atención.",
+  },
+  {
+    org: "Colegio KB",
+    industria: "Educación",
+    iniciales: "KB",
+    quote:
+      "TAEC nos ayudó a llegar a una implementación integral de ONE y NEO en nuestro colegio. Gracias a su colaboración podemos afirmar que estamos posicionados a la vanguardia de la educación a distancia en México.",
+  },
+  {
+    org: "Linktech",
+    industria: "Tecnología y capacitación",
+    iniciales: "LT",
+    quote:
+      "Escogimos a TAEC como nuestro socio en e-learning por su calidad, profesionalismo y conocimiento en la creación de estrategias de capacitación.",
+  },
+  {
+    org: "GS1 México",
+    industria: "Estándares globales de negocio",
+    iniciales: "GS",
+    quote:
+      "La colaboración con TAEC ha sido fructífera, hemos podido implementar exitosamente la plataforma de Totara y nos ayudaron a desarrollar el contenido que necesitábamos para las capacitaciones a distancia.",
+  },
+  {
+    org: "VivaAerobús",
+    industria: "Aviación",
+    iniciales: "VA",
+    quote:
+      "Articulate nos brinda la oportunidad de transformar contenido a un formato dinámico, atractivo y divertido para los cursos online que ofrecemos a nuestros colaboradores. Reducimos tiempos de desarrollo utilizando plantillas o diseñando desde cero.",
+  },
+  {
+    org: "Mosaic USA",
+    industria: "Servicios de e-learning",
+    iniciales: "MU",
+    quote:
+      "TAEC nos permitió respaldar el desarrollo de cursos y las necesidades gráficas y audiovisuales de nuestros clientes. Es un factor de crecimiento notable. Por el profesionalismo, anticipamos que nuestra relación continuará fortaleciéndose.",
+  },
+  {
+    org: "Fundación Omar Dengo",
+    industria: "Educación e innovación",
+    iniciales: "FO",
+    quote:
+      "Utilizamos Vyond para desarrollar modelos educativos innovadores centrados en las personas. Nos permite crear oportunidades de aprendizaje para el desarrollo y plena participación social y productiva de las personas en la sociedad del conocimiento.",
+  },
+];
 ---
 
 <BaseLayout 
@@ -12,95 +71,165 @@ import { r } from "../utils/paths";
   page="clientes.html"
 >
   <style is:global>
-
-  /* ── EN CONSTRUCCIÓN ── */
-    .wip-hero {
+    /* ── HERO ── */
+    .clientes-hero {
       background: linear-gradient(135deg, var(--navy) 0%, #00355a 100%);
-      padding: 72px 5%; text-align: center;
+      padding: 72px 5%;
+      text-align: center;
     }
-    .wip-hero-inner { max-width: 680px; margin: 0 auto; }
-    .wip-tag {
-      display: inline-flex; align-items: center; gap: 8px;
-      background: rgba(168,219,217,.15); color: var(--teal);
-      font-size: 11px; font-weight: 700; letter-spacing: 1.5px;
-      text-transform: uppercase; padding: 4px 14px; border-radius: 4px;
+    .clientes-hero-inner { max-width: 800px; margin: 0 auto; }
+    .clientes-hero h1 {
+      font-family: var(--font-display);
+      font-size: clamp(36px, 5vw, 48px);
+      color: var(--white);
+      line-height: 1.2;
       margin-bottom: 20px;
     }
-    .wip-icon {
-      font-size: 64px; margin-bottom: 20px; display: block;
-      filter: drop-shadow(0 4px 12px rgba(0,0,0,.3));
+    .clientes-hero p {
+      font-size: 18px;
+      color: #cbd5e1;
+      line-height: 1.6;
     }
-    .wip-hero h1 {
-      font-family: var(--font-display); font-size: 40px;
-      color: var(--white); line-height: 1.2; margin-bottom: 16px;
-    }
-    .wip-hero p {
-      font-size: 17px; color: #94A3B8; line-height: 1.75; margin-bottom: 32px;
-    }
-    .wip-card {
-      background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.12);
-      border-radius: 16px; padding: 32px; margin-top: 40px; text-align: left;
-    }
-    .wip-card-title {
-      font-size: 13px; font-weight: 700; text-transform: uppercase;
-      letter-spacing: 1px; color: var(--teal); margin-bottom: 16px;
-    }
-    .wip-features { display: flex; flex-direction: column; gap: 10px; }
-    .wip-feature {
-      display: flex; align-items: center; gap: 10px;
-      font-size: 14px; color: #CBD5E1;
-    }
-    .wip-feature::before { content: "⚡"; flex-shrink: 0; }
 
-    .wip-cta {
-      background: var(--light); padding: 64px 5%; text-align: center;
+    /* ── TESTIMONIOS GRID ── */
+    .testimonios-section {
+      padding: 72px 5%;
+      background: var(--light);
     }
-    .wip-cta-inner { max-width: 580px; margin: 0 auto; }
-    .wip-cta h2 { font-family: var(--font-display); font-size: 28px; color: var(--navy); margin-bottom: 12px; }
-    .wip-cta p { color: var(--dark); margin-bottom: 28px; line-height: 1.7; }
-    .wip-cta-btns { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
-    .btn-primary { display: inline-block; background: var(--orange); color: var(--white); padding: 13px 26px; border-radius: 8px; font-weight: 700; font-size: 14px; transition: background .15s; }
+    .testimonios-grid {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+    }
+    
+    .testimonio-card {
+      background: var(--white);
+      border: 1px solid rgba(0,0,0,.08);
+      border-radius: 12px;
+      padding: 32px 24px;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+    .testimonio-quote-mark {
+      font-family: var(--font-display);
+      font-size: 48px;
+      color: var(--teal);
+      line-height: 1;
+      margin-bottom: -10px;
+    }
+    .testimonio-quote {
+      font-size: 15px;
+      color: var(--dark);
+      line-height: 1.6;
+      flex-grow: 1;
+      margin-bottom: 32px;
+      font-style: italic;
+    }
+    .testimonio-author {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+    .testimonio-avatar {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: var(--teal);
+      color: var(--white);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 14px;
+      flex-shrink: 0;
+    }
+    .testimonio-info h3 {
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--navy);
+      margin-bottom: 4px;
+    }
+    .testimonio-info p {
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    /* ── CTA ── */
+    .cta-final {
+      padding: 72px 5%;
+      background: var(--white);
+      text-align: center;
+      border-top: 1px solid var(--border);
+    }
+    .cta-final h2 {
+      font-family: var(--font-display);
+      font-size: 32px;
+      color: var(--navy);
+      margin-bottom: 16px;
+    }
+    .cta-final p {
+      font-size: 16px;
+      color: var(--muted);
+      margin-bottom: 32px;
+      max-width: 600px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .btn-primary {
+      display: inline-block;
+      background: var(--orange);
+      color: var(--white);
+      padding: 14px 28px;
+      border-radius: 8px;
+      font-weight: 700;
+      font-size: 15px;
+      transition: background .15s;
+    }
     .btn-primary:hover { background: #d97b0e; }
-    .btn-wa { display: inline-flex; align-items: center; gap: 8px; background: #25D366; color: var(--white); padding: 13px 22px; border-radius: 8px; font-weight: 700; font-size: 14px; transition: background .15s; }
-    .btn-wa:hover { background: #1ebe5c; }
-    .btn-wa svg { width: 18px; height: 18px; fill: white; flex-shrink: 0; }
 
+    @media (max-width: 1024px) {
+      .testimonios-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 768px) {
+      .testimonios-grid { grid-template-columns: 1fr; }
+    }
   </style>
 
 <main id="main-content">
-
-<!-- ══ HERO EN CONSTRUCCIÓN ══ -->
-<section class="wip-hero">
-  <div class="wip-hero-inner">
-    <span class="wip-tag">Empresa</span>
-    <span class="wip-icon" role="img" aria-label="Clientes y Casos de Éxito">⭐</span>
-    <h1>Clientes y Casos de Éxito</h1>
-    <p>Empresas líderes en México y LATAM que confían en TAEC para su estrategia de capacitación corporativa.</p>
-    <div class="wip-card">
-      <p class="wip-card-title">🚧 Página en construcción</p>
-      <div class="wip-features">
-        <div class="wip-feature">Estamos preparando el contenido completo de esta página</div>
-        <div class="wip-feature">Mientras tanto, puedes escribirnos directamente y te respondemos en menos de 24 h</div>
-        <div class="wip-feature">Toda la información de precios, planes y soporte disponible por email o WhatsApp</div>
-      </div>
+  <section class="clientes-hero">
+    <div class="clientes-hero-inner">
+      <h1>Clientes que confían en TAEC</h1>
+      <p>Empresas líderes en México y LATAM que confían en TAEC para su estrategia de capacitación corporativa.</p>
     </div>
-  </div>
-</section>
+  </section>
 
-<!-- ══ CTA ══ -->
-<section class="wip-cta">
-  <div class="wip-cta-inner">
-    <h2>¿Necesitas información sobre Clientes y Casos de Éxito?</h2>
-    <p>Habla con uno de nuestros especialistas. Sin compromiso, sin demoras — respondemos el mismo día hábil.</p>
-    <div class="wip-cta-btns">
-      <a href={r('/contacto')} class="btn-primary">Escribirnos →</a>
-      <a href={contactData.whatsapp.url} target="_blank" rel="noopener noreferrer" class="btn-wa">
-        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>
-        WhatsApp
-      </a>
+  <section class="testimonios-section">
+    <div class="testimonios-grid">
+      {testimonios.map((t) => (
+        <div class="testimonio-card">
+          <div class="testimonio-quote-mark">"</div>
+          <p class="testimonio-quote">{t.quote}</p>
+          <div class="testimonio-author">
+            <div class="testimonio-avatar">{t.iniciales}</div>
+            <div class="testimonio-info">
+              <h3>{t.org}</h3>
+              <p>{t.industria}</p>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
-  </div>
-</section>
+  </section>
 
+  <section class="cta-final">
+    <div class="cta-inner">
+      <h2>¿Listo para impulsar tu capacitación?</h2>
+      <p>Únete a las empresas que ya están transformando el aprendizaje de sus equipos.</p>
+      <a href={r('/contacto')} class="btn-primary">Contáctanos →</a>
+    </div>
+  </section>
 </main>
 </BaseLayout>

--- a/astro-web/src/pages/index.astro
+++ b/astro-web/src/pages/index.astro
@@ -17,9 +17,9 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 const founded = new Date(2007, 9, 11);
 const now = new Date();
 const anni =
-	now.getFullYear() -
-	founded.getFullYear() -
-	(now < new Date(now.getFullYear(), 9, 11) ? 1 : 0);
+  now.getFullYear() -
+  founded.getFullYear() -
+  (now < new Date(now.getFullYear(), 9, 11) ? 1 : 0);
 
 export const prerender = false; // <-- CRITICO: Forza SSR para interceptar Headers de Netlify por visitante
 
@@ -31,28 +31,28 @@ const articulosColl = await getCollection("articulos").catch(() => []);
 const blogColl = await getCollection("blog").catch(() => []);
 
 const dbPosts = [...articulosColl, ...blogColl]
-	.map((p) => {
-		// En Astro 6, p.id es el identificador (e.g. "mi-post") dado por el glob loader
-		const finalSlug = p.id;
+  .map((p) => {
+    // En Astro 6, p.id es el identificador (e.g. "mi-post") dado por el glob loader
+    const finalSlug = p.id;
 
-		// Extraemos el año del string (ej: "Octubre 2, 2009" -> 2009). Si no hay fecha, asumimos el año actual.
-		const dateStr = p.data.date || p.data.fecha || "";
-		const yearMatch = dateStr.match(/\d{4}/);
-		const year = yearMatch
-			? parseInt(yearMatch[0], 10)
-			: new Date().getFullYear();
+    // Extraemos el año del string (ej: "Octubre 2, 2009" -> 2009). Si no hay fecha, asumimos el año actual.
+    const dateStr = p.data.date || p.data.fecha || "";
+    const yearMatch = dateStr.match(/\d{4}/);
+    const year = yearMatch
+      ? parseInt(yearMatch[0], 10)
+      : new Date().getFullYear();
 
-		return {
-			titulo: p.data.title || p.data.titulo || finalSlug.replace(/-/g, " "),
-			categoria:
-				p.data.category ||
-				p.data.categoria ||
-				(p.collection === "articulos" ? "Artículos" : "Blog"),
-			url: `/${p.collection}/${finalSlug}`,
-			year,
-		};
-	})
-	.filter((p) => p.year >= 2024); // Evita noticias Legacy (pre-2024) en la home
+    return {
+      titulo: p.data.title || p.data.titulo || finalSlug.replace(/-/g, " "),
+      categoria:
+        p.data.category ||
+        p.data.categoria ||
+        (p.collection === "articulos" ? "Artículos" : "Blog"),
+      url: `/${p.collection}/${finalSlug}`,
+      year,
+    };
+  })
+  .filter((p) => p.year >= 2024); // Evita noticias Legacy (pre-2024) en la home
 
 import fallbackTicker from "../../public/data/ticker.json";
 import { latamCountries, promos } from "../data/promos";
@@ -60,48 +60,48 @@ import { latamCountries, promos } from "../data/promos";
 // Lectura exhaustiva de País: Priorizando Contexto Nativo de Netlify Edge > Cabecera Netlify > Fallback
 const netlifyGeo = Astro.locals.netlify?.context?.geo?.country?.code;
 const headerGeo =
-	Astro.request.headers.get("x-country") ||
-	Astro.request.headers.get("x-nf-country");
+  Astro.request.headers.get("x-country") ||
+  Astro.request.headers.get("x-nf-country");
 const countryCode = netlifyGeo || headerGeo || "MX";
 const isLatam = latamCountries.includes(countryCode);
 
 const activePromos = promos.filter(
-	(p) =>
-		p.active &&
-		(p.countries.includes(countryCode) ||
-			(isLatam && p.countries.includes("LATAM")) ||
-			p.countries.includes("GLOBAL")),
+  (p) =>
+    p.active &&
+    (p.countries.includes(countryCode) ||
+      (isLatam && p.countries.includes("LATAM")) ||
+      p.countries.includes("GLOBAL")),
 );
 
 const basePool: any[] =
-	dbPosts.length > 5
-		? dbPosts.sort(() => 0.5 - Math.random()).slice(0, 15)
-		: fallbackTicker;
+  dbPosts.length > 5
+    ? dbPosts.sort(() => 0.5 - Math.random()).slice(0, 15)
+    : fallbackTicker;
 let tickerPool: any[] = [];
 
 if (activePromos.length > 0) {
-	const promoItems = activePromos.map((p) => ({
-		titulo: p.title,
-		categoria: p.badgeText.replace(/[^\w\s%·]/g, "").trim() || "OFERTA",
-		url: p.link || "#",
-		isPromo: true,
-		color: p.color || "#c2410c",
-	}));
+  const promoItems = activePromos.map((p) => ({
+    titulo: p.title,
+    categoria: p.badgeText.replace(/[^\w\s%·]/g, "").trim() || "OFERTA",
+    url: p.link || "#",
+    isPromo: true,
+    color: p.color || "#c2410c",
+  }));
 
-	// Patrón: 2 posts normales → 1 promo (rotando entre todas las promos activas)
-	let normalCount = 0;
-	let promoIdx = 0;
-	for (let i = 0; i < basePool.length; i++) {
-		tickerPool.push(basePool[i]);
-		normalCount++;
-		if (normalCount === 2) {
-			tickerPool.push(promoItems[promoIdx % promoItems.length]);
-			promoIdx++;
-			normalCount = 0;
-		}
-	}
+  // Patrón: 2 posts normales → 1 promo (rotando entre todas las promos activas)
+  let normalCount = 0;
+  let promoIdx = 0;
+  for (let i = 0; i < basePool.length; i++) {
+    tickerPool.push(basePool[i]);
+    normalCount++;
+    if (normalCount === 2) {
+      tickerPool.push(promoItems[promoIdx % promoItems.length]);
+      promoIdx++;
+      normalCount = 0;
+    }
+  }
 } else {
-	tickerPool = basePool;
+  tickerPool = basePool;
 }
 ---
 
@@ -373,19 +373,19 @@ if (activePromos.length > 0) {
         <div class="clientes-marquee reveal-up">
           <div class="clientes-track">
             <!-- Set 1 -->
-            <div class="cliente-logo-pill"><span>GS1</span></div>
-            <div class="cliente-logo-pill"><span>VivaAerobús</span></div>
-            <div class="cliente-logo-pill"><span>UNICEF</span></div>
-            <div class="cliente-logo-pill"><span>OIM</span></div>
-            <div class="cliente-logo-pill"><span>Peñoles</span></div>
-            <div class="cliente-logo-pill"><span>Tec de Monterrey</span></div>
+            <div class="cliente-logo-pill brand-gs1"><span>GS1</span></div>
+            <div class="cliente-logo-pill brand-viva"><span>VivaAerobús</span></div>
+            <div class="cliente-logo-pill brand-unicef"><span>UNICEF</span></div>
+            <div class="cliente-logo-pill brand-oim"><span>OIM</span></div>
+            <div class="cliente-logo-pill brand-penoles"><span>Peñoles</span></div>
+            <div class="cliente-logo-pill brand-tec"><span>Tec de Monterrey</span></div>
             <!-- Set 2 (Duplicado para loop infinito) -->
-            <div class="cliente-logo-pill"><span>GS1</span></div>
-            <div class="cliente-logo-pill"><span>VivaAerobús</span></div>
-            <div class="cliente-logo-pill"><span>UNICEF</span></div>
-            <div class="cliente-logo-pill"><span>OIM</span></div>
-            <div class="cliente-logo-pill"><span>Peñoles</span></div>
-            <div class="cliente-logo-pill"><span>Tec de Monterrey</span></div>
+            <div class="cliente-logo-pill brand-gs1"><span>GS1</span></div>
+            <div class="cliente-logo-pill brand-viva"><span>VivaAerobús</span></div>
+            <div class="cliente-logo-pill brand-unicef"><span>UNICEF</span></div>
+            <div class="cliente-logo-pill brand-oim"><span>OIM</span></div>
+            <div class="cliente-logo-pill brand-penoles"><span>Peñoles</span></div>
+            <div class="cliente-logo-pill brand-tec"><span>Tec de Monterrey</span></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #107
Closes #108

Se ha implementado la página `/clientes` con 8 testimonios reales usando CSS puro para avatares y grid responsive, y se han aplicado los colores de marca mediante clases de CSS (`brand-*`) a los elementos del ticker en la página principal tal y como se define en la especificación.
*(Screenshot visual pendiente de añadir por revisor humano).*