### PR TITLE
Fix: supabaseUrl empty in rag.ts during SSR (Issue #137)

### DIFF
--- a/astro-web/src/lib/tito/rag.ts
+++ b/astro-web/src/lib/tito/rag.ts
@@ -19,10 +19,15 @@ const getSafeEnv = (k: string) => {
 };
 
 const supabaseUrl =
-	getSafeEnv("SUPABASE_URL") ?? getSafeEnv("PUBLIC_SUPABASE_URL") ?? "";
+	(import.meta.env && import.meta.env.PUBLIC_SUPABASE_URL) ||
+	getSafeEnv("SUPABASE_URL") ||
+	getSafeEnv("PUBLIC_SUPABASE_URL") ||
+	"";
 const supabaseKey =
-	getSafeEnv("SUPABASE_SERVICE_ROLE_KEY") ??
-	getSafeEnv("PUBLIC_SUPABASE_ANON_KEY") ??
+	(import.meta.env && import.meta.env.SUPABASE_SERVICE_ROLE_KEY) ||
+	(import.meta.env && import.meta.env.PUBLIC_SUPABASE_ANON_KEY) ||
+	getSafeEnv("SUPABASE_SERVICE_ROLE_KEY") ||
+	getSafeEnv("PUBLIC_SUPABASE_ANON_KEY") ||
 	"";
 const geminiApiKey =
 	getSafeEnv("TAEC_GEMINI_KEY") ?? getSafeEnv("GEMINI_API_KEY") ?? "";


### PR DESCRIPTION
Resolves #137. 

This PR rescues the stranded hotfix for the `supabaseUrl is required` SSR/Vite HMR crash, originally authored in the now-merged feature branch. It evaluates `import.meta.env` literals directly in `rag.ts` ensuring the proxy correctly passes down environment variables during module evaluation.