### PR TITLE
fix(ProductPageLayout): HeroComercial/CtaFinal not defined in SSR — convert import type to value imports

### DIFF
--- a/astro-web/src/layouts/ProductPageLayout.astro
+++ b/astro-web/src/layouts/ProductPageLayout.astro
@@ -1,8 +1,8 @@
 ---
-import type CtaFinal from "../components/ui/CtaFinal.astro";
+import CtaFinal from "../components/ui/CtaFinal.astro";
 import FAQAccordion from "../components/ui/FAQAccordion.astro";
 import GridBeneficios from "../components/ui/GridBeneficios.astro";
-import type HeroComercial from "../components/ui/HeroComercial.astro";
+import HeroComercial from "../components/ui/HeroComercial.astro";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {


### PR DESCRIPTION
## Problema

Error en producción desde Apr 26, 20:46 UTC. Todas las páginas que usan `ProductPageLayout` (moodle, articulate, vyond, totara, etc.) devuelven 500:

```
ReferenceError: HeroComercial is not defined
  at ProductPageLayout_DNaOMop3.mjs:13
```

## Causa raíz

`import type` es eliminado por TypeScript/Vite en tiempo de compilación — solo existe para el type-checker. Al ejecutar SSR en Netlify, las variables `HeroComercial` y `CtaFinal` no existen como valores, por lo que el template falla al intentar renderizarlas.

## Fix

```diff
- import type CtaFinal from "../components/ui/CtaFinal.astro";
+ import CtaFinal from "../components/ui/CtaFinal.astro";
- import type HeroComercial from "../components/ui/HeroComercial.astro";
+ import HeroComercial from "../components/ui/HeroComercial.astro";
```

`Parameters<typeof HeroComercial>[0]` para tipar las props sigue funcionando con imports normales — TypeScript puede inferir el tipo desde el valor.

## Archivos afectados

- `astro-web/src/layouts/ProductPageLayout.astro` — 2 líneas

## Test

Deploy en Netlify preview y verificar que `/moodle-mexico`, `/articulate-360-mexico`, `/vyond-mexico`, `/totara-lms-mexico` cargan sin 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)