### PR TITLE
fix(tito): escalate keywords + transition:persist (#148 #149)

### DIFF
--- a/astro-web/src/layouts/BaseLayout.astro
+++ b/astro-web/src/layouts/BaseLayout.astro
@@ -158,7 +158,7 @@ const ogImageURL = new URL(
   </a>
   )}
 
-  <ChatAgent client:load isApp={isApp} userName={Astro.locals?.user?.name || Astro.locals?.name || 'Visitante'} />
+  <ChatAgent client:load transition:persist isApp={isApp} userName={Astro.locals?.user?.name || Astro.locals?.name || 'Visitante'} />
   <script is:inline src={`${base}assets/js/nav.js`} defer></script>
   <script>
     let globalRevealObserver = null;

--- a/astro-web/src/lib/tito/rules.ts
+++ b/astro-web/src/lib/tito/rules.ts
@@ -46,10 +46,6 @@ export function evaluateMessageForEscalation(
 		"renovación",
 		"renovacion",
 		"renovar",
-		"comprar",
-		"compra",
-		"comprarlo",
-		"adquirir",
 		"edu",
 		"universidad",
 		"colegio",
@@ -84,6 +80,10 @@ export function evaluateMessageForEscalation(
 		"cotizacion",
 		"costo",
 		"descuento",
+		"comprar",
+		"compra",
+		"comprarlo",
+		"adquirir",
 	];
 
 	if (informKeywords.some((kw) => msgLower.includes(kw))) {


### PR DESCRIPTION
## Cambios

### fix #148 — comprar/adquirir ya no dispara ESCALATE inmediato

`rules.ts`: las keywords `comprar`, `compra`, `comprarlo`, `adquirir` se movieron de `escalateKeywords` a `informKeywords`. Ahora Tito responde con información del producto antes de pedir datos de contacto.

**Antes:** "quiero comprar Articulate" → pide nombre/empresa/correo de inmediato  
**Después:** "quiero comprar Articulate" → da info del producto + precio → luego escala si el usuario confirma

Keywords que siguen en `escalateKeywords` (flujo correcto): `renovar`, `renovación`, `lms`, sectores edu, servicios, implementación.

### fix #149 — ChatAgent ya no se desmonta al navegar

`BaseLayout.astro:161`: se agregó `transition:persist` al componente `ChatAgent`. Con Astro View Transitions, sin esta directiva el componente se destruye y remonta en cada navegación, perdiendo el estado del chat.

## Archivos

- `astro-web/src/lib/tito/rules.ts`
- `astro-web/src/layouts/BaseLayout.astro`

## Test

- Escribir "quiero comprar Articulate" → Tito informa, no pide datos
- Navegar entre páginas con chat abierto → chat permanece abierto sin parpadeo

🤖 Generated with [Claude Code](https://claude.com/claude-code)