### PR TITLE
feat(tito): session-only chat persistence via sessionStorage (closes #150)

### DIFF
--- a/astro-web/src/stores/chatStore.ts
+++ b/astro-web/src/stores/chatStore.ts
@@ -2,7 +2,7 @@ import { persistentAtom, setPersistentEngine } from "@nanostores/persistent";
 import { atom } from "nanostores";
 
 if (typeof window !== "undefined") {
-	setPersistentEngine(window.localStorage, {
+	setPersistentEngine(window.sessionStorage, {
 		addEventListener(key, handler) {
 			window.addEventListener("storage", handler as any);
 		},
@@ -140,7 +140,7 @@ export const v3_2RolloutStore = persistentAtom<boolean>(
 export const initializeRollout = () => {
 	if (
 		typeof window !== "undefined" &&
-		!localStorage.getItem("tito:v3_2Rollout")
+		!sessionStorage.getItem("tito:v3_2Rollout")
 	) {
 		const isDesktop = window.innerWidth > 768;
 		const isSelected = Math.random() < 0.1; // 10% sesiones desktop


### PR DESCRIPTION
## Cambio

Migra el engine de persistencia de TitoBits de `localStorage` a `sessionStorage`.

**Comportamiento anterior:** la conversación sobrevivía al cerrar y reabrir el navegador (localStorage persiste indefinidamente).

**Comportamiento nuevo:** la conversación se limpia automáticamente al cerrar la pestaña o el navegador. Al abrir una nueva sesión, Tito saluda de nuevo desde cero.

## Por qué sessionStorage y no TTL

`sessionStorage` es la primitiva exacta para este caso: el browser gestiona el ciclo de vida sin necesidad de timestamps, comparaciones ni lógica de limpieza. Más simple y sin riesgo de bugs de reloj.

## Archivos

- `astro-web/src/stores/chatStore.ts` — 2 líneas

## Test

1. Abrir el chat y escribir algunos mensajes
2. Cerrar la pestaña y abrir una nueva → Tito saluda de nuevo ✓
3. Navegar entre páginas sin cerrar la pestaña → conversación se mantiene ✓ (sessionStorage sobrevive navegación intra-tab)

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)