### PR TITLE
fix(tito): links de contacto clickeables en fallback

### DIFF
--- a/astro-web/src/lib/tito/handoff.ts
+++ b/astro-web/src/lib/tito/handoff.ts
@@ -1,14 +1,16 @@
 /**
  * @name handoff.ts
- * @version 1.1
+ * @version 1.2
  * @description Funciones para generar mini briefs de leads y notificar vía Webhook y Correo (Resend).
  * @inputs Record del lead estructurado
  * @outputs Promesa vacía o respuesta de la API de comunicación.
  * @dependencies node-fetch / native fetch
  * @created 2026-04-11
- * @updated 2026-04-23 10:46:00
+ * @updated 2026-04-28
  *
  * Changelog:
+ *   v1.2 (2026-04-28) — Autor: Antigravity
+ *     - [FIX] Enlaces de contacto hechos clickeables en FALLBACK_CONTACTO.
  *   v1.1 (2026-04-23) — Autor: Antigravity
  *     - [FIX] Resolución de env vars compatible con Astro SSR (import.meta.env + process.env)
  */
@@ -104,8 +106,8 @@ export async function enviarNotificacion(lead: LeadData) {
 
 // Constante de fallback — hardcodeada, no generada por LLM
 export const FALLBACK_CONTACTO = `Sin problema. Puedes contactarnos directamente:
-• Correo: info@taec.com.mx
-• WhatsApp: https://api.whatsapp.com/send/?phone=5215527758279`;
+• Correo: [info@taec.com.mx](mailto:info@taec.com.mx)
+• WhatsApp: [Escríbenos por WhatsApp](https://api.whatsapp.com/send/?phone=5215527758279)`;
 
 // Extrae nombre, empresa y email de un mensaje de texto libre
 export function extraerContacto(message: string): {

--- a/astro-web/src/pages/api/agente-ia.ts
+++ b/astro-web/src/pages/api/agente-ia.ts
@@ -1,13 +1,17 @@
 /**
  * @name agente-ia.ts
- * @version v1.5
+ * @version v1.6
  * @description Endpoint Backend principal para el agente de IA Tito Bits (Motor 3 - Generativo).
  * Realiza RAG contra la base de conocimientos y despacha SSEs hacia el frontend.
  * @inputs Request body con historiales de chat y metadata geopolítica del lead.
  * @outputs Response en texto continuo usando ReadableStream (SSE).
  * @dependencies @google/generative-ai, titoKnowledgeBase
  * @created 2024-03-01
- * @updated 2026-04-12 17:55:00
+ * @updated 2026-04-28
+ *
+ * Changelog:
+ *   v1.6 (2026-04-28) — Autor: Antigravity
+ *     - [FIX] Enlaces de contacto (email y whatsapp) hechos clickeables en el prompt de fallback.
  */
 export const prerender = false;
 
@@ -510,8 +514,8 @@ Si el usuario dice que no quiere dar sus datos o información
 de contacto, responde EXACTAMENTE esto (sin modificar):
 
 "Sin problema. Puedes contactarnos directamente:
-• Correo: info@taec.com.mx
-• WhatsApp: https://api.whatsapp.com/send/?phone=5215527758279"
+• Correo: [info@taec.com.mx](mailto:info@taec.com.mx)
+• WhatsApp: [Escríbenos por WhatsApp](https://api.whatsapp.com/send/?phone=5215527758279)"
 
 No agregues nada más. No sigas intentando capturar datos.
 


### PR DESCRIPTION
Fixes #167. Transforma los links de texto plano en fallback de contacto en el agente IA a enlaces markdown clickeables. JSDoc y changelogs actualizados según el estándar.