### PR TITLE
fix: add iSpring example to titoKnowledgeBase to prevent evaluation (fixes #173)

### DIFF
--- a/astro-web/src/data/titoKnowledgeBase.ts
+++ b/astro-web/src/data/titoKnowledgeBase.ts
@@ -1,7 +1,7 @@
 /**
  * @name titoKnowledgeBase
- * @version 6.6
- * @date 2026-04-28
+ * @version 6.7
+ * @date 2026-04-29
  * @owner TAEC / Dirección Comercial
  * @status Borrador — pendiente pruebas controladas con leads reales antes de subir a GitHub
  * @vigencia Revisión trimestral
@@ -14,6 +14,9 @@
  *   - Auditoría de Red Team (Stress Tests de Pricing y Enrutamiento)
  *
  * Changelog:
+ *   v6.7 (2026-04-29) — Autor: Antigravity
+ *     - [FIX] Issue #173: Agregar ejemplo explícito para evitar evaluación errónea de implementaciones de iSpring.
+ *
  *   v6.6 (2026-04-28) — Autor: Antigravity
  *     - [FIX] Issue #172: Actualizar agenda del Corporate Learning Summit a URL pública en evento_summit.
  *
@@ -158,6 +161,10 @@ Si el usuario intenta llevar la conversación a productos no comercializados por
 1. TIENES ESTRICTAMENTE PROHIBIDO COTIZAR O RESPALDAR SOLUCIONES FUERA DEL PORTAFOLIO TAEC.
 2. No rechaces de forma robótica. Debes redirigir hacia una "comparación consultiva enfocada en resultados".
 3. Respuesta modelo: "Conozco cómo operan los equipos con [Producto Mencionado], sin embargo, basado en tu necesidad de [Objetivo], nuestro ecosistema de Articulate 360 (o Totara/Vyond) te ofrece [Ventaja Competitiva]. ¿Te gustaría que revisemos cómo migrar o adaptar esa funcionalidad a nuestra tecnología?"
+
+[1.3] Ejemplo iSpring:
+Usuario: '¿Pueden ayudarme a implementar iSpring?'
+Respuesta correcta: 'TAEC no implementa productos fuera de nuestro portafolio. Sin embargo, si tu objetivo es [X], nuestro ecosistema con [Totara/Moodle + Articulate] te ofrece [ventaja]. ¿Te gustaría que revisemos cómo cubrimos esa necesidad con nuestra tecnología?'
 
 [1.4] Principio Comercial
 TAEC vende ecosistemas, servicios y resultados.


### PR DESCRIPTION
Resolves #173 by explicitly adding an example for iSpring within the `[1.3] Defensa de Portafolio` section of `titoKnowledgeBase.ts`. This ensures that the TitoBits model correctly redirects queries about implementing non-portfolio products rather than inappropriately assessing them. JSDoc version and changelog have also been updated.