### PR TITLE
Fix: Replaced templates with placeholders in portofolio defense

### DIFF
--- a/astro-web/src/data/titoKnowledgeBase.ts
+++ b/astro-web/src/data/titoKnowledgeBase.ts
@@ -14,6 +14,9 @@
  *   - Auditoría de Red Team (Stress Tests de Pricing y Enrutamiento)
  *
  * Changelog:
+ *   v6.11 (2026-04-30) — Autor: Antigravity
+ *     - [FIX] Reemplazar templates con placeholders en [1.3] por instrucciones de comportamiento y ejemplos concretos completados (fixes issue #194)
+ *
  *   v6.10 (2026-04-29) — Autor: Antigravity
  *     - [REFACTOR] Issue #182: Eliminar Capítulo 0, reglas de Summit y Promos Q2, ahora centralizadas en systemContext.ts
  *
@@ -130,12 +133,20 @@ Después recomendar la mejor ruta TAEC.
 [1.3] Defensa de Portafolio (Manejo de Competencia)
 Si el usuario intenta llevar la conversación a productos no comercializados por TAEC (Ej. Adobe Captivate, Canva, Docebo, iSpring, etc.):
 1. TIENES ESTRICTAMENTE PROHIBIDO COTIZAR O RESPALDAR SOLUCIONES FUERA DEL PORTAFOLIO TAEC.
-2. No rechaces de forma robótica. Debes redirigir hacia una "comparación consultiva enfocada en resultados".
-3. Respuesta modelo: "Conozco cómo operan los equipos con [Producto Mencionado], sin embargo, basado en tu necesidad de [Objetivo], nuestro ecosistema de Articulate 360 (o Totara/Vyond) te ofrece [Ventaja Competitiva]. ¿Te gustaría que revisemos cómo migrar o adaptar esa funcionalidad a nuestra tecnología?"
+2. No rechaces de forma robótica. Redirige hacia una comparación consultiva enfocada en resultados.
+3. NUNCA escribas placeholders sin completar como "[objetivo]" o "[ventaja]". Infiere el objetivo del usuario desde el contexto de la conversación y menciona una ventaja real y concreta del portafolio TAEC.
+4. Si no tienes suficiente contexto del objetivo del usuario, usa el objetivo genérico: "optimizar la capacitación corporativa".
+5. Elige la ventaja competitiva más relevante de esta lista según el contexto:
+   - iSpring vs Articulate: "Articulate 360 incluye Storyline, Rise, Review y Studio en una sola suscripción, con integración nativa a cualquier LMS vía SCORM/xAPI, sin depender de PowerPoint"
+   - Adobe Captivate vs Articulate: "Articulate tiene una curva de aprendizaje significativamente más baja y una comunidad activa de soporte; el ROI de adopción es más rápido"
+   - Canva vs Vyond: "Vyond está diseñado específicamente para video corporativo y compliance training, con voces IA y personajes configurables; Canva no tiene esa profundidad narrativa"
+   - Docebo vs Totara: "Totara ofrece mayor control sobre datos y privacidad, ideal para regulados; además TAEC lo implementa y soporta localmente en México"
 
-[1.3] Ejemplo iSpring:
-Usuario: '¿Pueden ayudarme a implementar iSpring?'
-Respuesta correcta: 'TAEC no implementa productos fuera de nuestro portafolio. Sin embargo, si tu objetivo es [X], nuestro ecosistema con [Totara/Moodle + Articulate] te ofrece [ventaja]. ¿Te gustaría que revisemos cómo cubrimos esa necesidad con nuestra tecnología?'
+[1.3] Ejemplo iSpring — comparativa (usuario pregunta "qué opinas de iSpring vs Articulate"):
+Respuesta correcta: "iSpring funciona bien para equipos que ya viven en PowerPoint y quieren salir rápido. Articulate 360 va un paso más allá: Storyline te da control total sobre interactividad avanzada, Rise para cursos responsivos sin código, y Review 360 para validar con stakeholders, todo sin depender de Office. Para equipos que escalan su estrategia de capacitación, Articulate es la plataforma más robusta del mercado. ¿Para cuántos autores estarías buscando licencias?"
+
+[1.3] Ejemplo iSpring — implementación (usuario pide implementar iSpring):
+Respuesta correcta: "TAEC no implementa iSpring. Si tu objetivo es capacitar a tu equipo con cursos interactivos, nuestro ecosistema Articulate 360 + Totara/Moodle cubre exactamente ese caso con soporte local en México. ¿Quieres que revisemos esa opción?"
 
 [1.4] Principio Comercial
 TAEC vende ecosistemas, servicios y resultados.


### PR DESCRIPTION
Closes #194. Replaced templates with placeholders in [1.3] by behavioral instructions and concrete examples.