### PR TITLE
chore: revert typescript to 5.9.3

### DIFF
--- a/astro-web/package-lock.json
+++ b/astro-web/package-lock.json
@@ -38,7 +38,7 @@
         "@astrojs/check": "^0.9.8",
         "@biomejs/biome": "^2.4.12",
         "@playwright/test": "^1.59.1",
-        "typescript": "^6.0.3",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.4"
       },
       "engines": {
@@ -12685,19 +12685,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/precinct/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/prettier": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
@@ -14856,9 +14843,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/astro-web/package.json
+++ b/astro-web/package.json
@@ -48,7 +48,7 @@
     "@astrojs/check": "^0.9.8",
     "@biomejs/biome": "^2.4.12",
     "@playwright/test": "^1.59.1",
-    "typescript": "^6.0.3",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.4"
   }
 }


### PR DESCRIPTION
Revert TypeScript from 6.0.3 to 5.9.3 to address `npx astro check` errors and peer dependency conflicts with `@astrojs/check`.\n\nNote: During verification, `npx astro check` still reported 195 errors with TypeScript 5.9.3 due to the pre-existing `astro/tsconfigs/strict` configuration. The downgrade primarily resolves the peer dependency mismatch with `@astrojs/check` which failed during `npm ci`.\n\nResolves #207