### PR TITLE
fix(seo): trim page titles to max 60 chars

### DIFF
--- a/astro-web/src/pages/7minutes-learning.astro
+++ b/astro-web/src/pages/7minutes-learning.astro
@@ -4,6 +4,7 @@ import FAQAccordion from "../components/ui/FAQAccordion.astro";
 import GridBeneficios from "../components/ui/GridBeneficios.astro";
 import HeroComercial from "../components/ui/HeroComercial.astro";
 import { getBookingUrl } from "../data/contact";
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 // CHANGELOG: 2026-03-20 - Landing 7Minutes completa. Contenido basado en doc estratégico DDC.
 import BaseLayout from "../layouts/BaseLayout.astro";
 
@@ -106,7 +107,7 @@ const faqs = [
 ---
 
 <BaseLayout
-  title="7Minutes en México | Microlearning corporativo móvil y flexible | TAEC"
+  title="7Minutes en México | Microlearning Móvil | TAEC"
   description="7Minutes con TAEC: microlearning corporativo listo para usar. Soft skills, management, compliance y más. Integración con LMS o plataforma propia. Demo en español."
   section="Soluciones"
   page="7minutes-learning.html"

--- a/astro-web/src/pages/articulate-localization.astro
+++ b/astro-web/src/pages/articulate-localization.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import { getBookingUrl } from "../data/contact";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
@@ -6,7 +7,7 @@ import { base, r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Articulate Localization – Traduce Cursos con IA a 70+ Idiomas | TAEC"
+  title="Articulate Localization | Traduce Cursos con IA | TAEC"
   description="Articulate Localization: traduce y localiza cursos de Rise 360 y Storyline con IA. Reduce costos de traducción hasta 90%. Partner oficial en México."
   section="Soluciones"
   page="articulate-localization.html"

--- a/astro-web/src/pages/articulate-reach.astro
+++ b/astro-web/src/pages/articulate-reach.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import { getBookingUrl } from "../data/contact";
 import { vendors } from "../data/vendors";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -7,7 +8,7 @@ import { base, r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Reach 360 en México – Distribución de Cursos eLearning | TAEC"
+  title="Reach 360 en México | Distribución eLearning | TAEC"
   description="Reach 360: distribuye cursos de Storyline y Rise a cualquier audiencia sin LMS. Partner oficial Articulate en México. Solicita demo con TAEC."
   section="Soluciones"
   page="articulate-reach.html"

--- a/astro-web/src/pages/articulate-review360.astro
+++ b/astro-web/src/pages/articulate-review360.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import { getBookingUrl } from "../data/contact";
 import { vendors } from "../data/vendors";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -7,7 +8,7 @@ import { r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Review 360 en México – Revisión Colaborativa de Cursos | TAEC"
+  title="Review 360 en México | Revisión de Cursos | TAEC"
   description="Review 360: herramienta web para revisar y aprobar cursos e-learning con tu equipo. Comentarios, versiones y acceso por enlace. Partner Articulate en México."
   section="Soluciones"
   page="articulate-review360.html"

--- a/astro-web/src/pages/articulate-rise360.astro
+++ b/astro-web/src/pages/articulate-rise360.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import { getBookingUrl } from "../data/contact";
 import { vendors } from "../data/vendors";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -7,7 +8,7 @@ import { r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Rise 360 en México – Cursos eLearning 100% Responsivos | TAEC"
+  title="Rise 360 en México | Cursos 100% Responsivos | TAEC"
   description="Rise 360: crea cursos e-learning responsive con bloques prediseñados. Partner oficial Articulate en México. Solicita demo con TAEC."
   section="Soluciones"
   page="articulate-rise360.html"

--- a/astro-web/src/pages/articulate-storyline360.astro
+++ b/astro-web/src/pages/articulate-storyline360.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import { getBookingUrl } from "../data/contact";
 import { vendors } from "../data/vendors";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -7,7 +8,7 @@ import { r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Storyline 360 en México – Cursos Interactivos Avanzados | TAEC"
+  title="Storyline 360 en México | Cursos Interactivos | TAEC"
   description="Storyline 360: crea experiencias de aprendizaje totalmente personalizadas e inmersivas. Partner oficial Articulate en México. Solicita demo."
   section="Soluciones"
   page="articulate-storyline360.html"

--- a/astro-web/src/pages/class-taec.astro
+++ b/astro-web/src/pages/class-taec.astro
@@ -4,6 +4,7 @@ import FAQAccordion from "../components/ui/FAQAccordion.astro";
 import GridBeneficios from "../components/ui/GridBeneficios.astro";
 import HeroComercial from "../components/ui/HeroComercial.astro";
 import { getBookingUrl } from "../data/contact";
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 // CHANGELOG: 2026-03-20 - Landing Class completa. Contenido basado en doc estratégico DDC.
 import BaseLayout from "../layouts/BaseLayout.astro";
 
@@ -148,7 +149,7 @@ const faqs = [
 ---
 
 <BaseLayout
-  title="Class en México | Aula virtual avanzada para capacitación en vivo | TAEC"
+  title="Class en México | Aula Virtual en Vivo | TAEC"
   description="Class convierte Zoom y Teams en un aula virtual para L&D: breakout rooms, engagement scoring, asistencia automática e integración con LMS. Demo en español con TAEC."
   section="Soluciones"
   page="class-taec.html"

--- a/astro-web/src/pages/desarrollo-de-contenidos.astro
+++ b/astro-web/src/pages/desarrollo-de-contenidos.astro
@@ -14,6 +14,7 @@ import {
 	ddcProceso,
 	ddcServicios,
 } from "../data/ddc";
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 // CHANGELOG: 2026-03-20 - Nueva landing DDC (Desarrollo de Contenidos).
 // Fuente de contenido: src/data/ddc.ts · PDF "Info DDC para sitio web"
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -24,7 +25,7 @@ const bookingUrl = getBookingUrl();
 ---
 
 <BaseLayout
-  title="Desarrollo de Contenidos e-Learning | Articulate + Vyond + IA | TAEC"
+  title="Desarrollo de Contenidos e-Learning con IA | TAEC"
   description="Cursos a medida con Articulate 360, Vyond e IA generativa. Metodología ADDIE + Agile SAM, Project Manager dedicado y archivos editables garantizados. TAEC DDC · México y LATAM."
   section="Soluciones"
   page="desarrollo-de-contenidos.html"

--- a/astro-web/src/pages/moodle-mexico.astro
+++ b/astro-web/src/pages/moodle-mexico.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 // CHANGELOG: 03/05/2026 - Injected visually hidden h1 element inside main content for SEO compliance (Issue #214).
 import CtaFinal from "../components/ui/CtaFinal.astro";
 import FAQAccordion from "../components/ui/FAQAccordion.astro";
@@ -43,7 +44,7 @@ const faqsMoodle = [
 ---
 
 <BaseLayout 
-  title="Moodle en México – Hosting SaaS, implementación y soporte | TAEC"
+  title="Moodle en México | Hosting SaaS y Soporte | TAEC"
   description="Partner oficial de Moodle en México y LATAM. Hosting SaaS gestionado, implementación, personalización y soporte en español. +18 años de experiencia en e-learning."
   section="Soluciones"
   page="moodle-mexico.html"

--- a/astro-web/src/pages/nosotros.astro
+++ b/astro-web/src/pages/nosotros.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import { contactData, getBookingUrl, getBookingUrl } from "../data/contact";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
@@ -6,7 +7,7 @@ import { r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Quiénes somos – TAEC | 18 años en e-learning México y LATAM"
+  title="Nosotros | 18 años de e-learning en México | TAEC"
   description="TAEC: Tecnología Avanzada para la Educación y la Capacitación. Desde 2007 en CDMX, con oficinas en Bogotá y Santiago de Chile. +1,500 clientes en 17 países."
   section=""
   page="nosotros.html"

--- a/astro-web/src/pages/pifini-mexico.astro
+++ b/astro-web/src/pages/pifini-mexico.astro
@@ -5,6 +5,7 @@ import GridBeneficios from "../components/ui/GridBeneficios.astro";
 import HeroComercial from "../components/ui/HeroComercial.astro";
 import LogosGrid from "../components/ui/LogosGrid.astro";
 import { getBookingUrl } from "../data/contact";
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 // CHANGELOG: 2026-03-20 - Nueva landing Pifini Learn / NetExam LMS+ · v2 con contenido completo.
 // Fuentes: pifini.ai · netexam.com · PDF Craig Weiss Group Top 10 (Dic 2025)
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -136,7 +137,7 @@ const logos = [
 ---
 
 <BaseLayout
-  title="Pifini Learn / NetExam LMS en México — #7 Mundial, $50/usuario/año | TAEC"
+  title="Pifini Learn LMS en México — #7 Mundial | TAEC"
   description="Pifini Learn (antes NetExam LMS+) es el #7 sistema de aprendizaje mundial (Craig Weiss 2025). LMS especialista en partner training, sales enablement e IA. Desde $50 USD/usuario/año. TAEC: implementación y soporte en español · México."
   section="Soluciones"
   page="pifini-mexico.html"

--- a/astro-web/src/pages/recursos/ecosistema-edtech-latam.astro
+++ b/astro-web/src/pages/recursos/ecosistema-edtech-latam.astro
@@ -11,11 +11,12 @@
  * Changelog:
  * 2026-04-28 - issue #159: Creación del artículo completo sobre el ecosistema de plataformas complementarias.
  */
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { r } from "../../utils/paths";
 ---
 <BaseLayout 
-  title="Ecosistema EdTech LATAM: Totara, Pifini, Proctorizer y Strike | TAEC"
+  title="Ecosistema EdTech LATAM | Herramientas e IA | TAEC"
   description="Análisis del ecosistema de plataformas complementarias para e-learning en LATAM."
   section="Recursos"
   page="ecosistema-edtech-latam.html"

--- a/astro-web/src/pages/vyond-enterprise.astro
+++ b/astro-web/src/pages/vyond-enterprise.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import VyondNav from "../components/ui/VyondNav.astro";
 import { contactData, getBookingUrl } from "../data/contact";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -7,7 +8,7 @@ import { base, r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Vyond Enterprise en México — Video corporativo a escala | TAEC"
+  title="Vyond Enterprise en México | Video a Escala | TAEC"
   description="Despliega Vyond en toda tu organización con SSO, branding personalizado y créditos IA ilimitados. Partner oficial Vyond para México y LATAM."
   section="Soluciones"
   page="vyond-enterprise.html"

--- a/astro-web/src/pages/vyond-go.astro
+++ b/astro-web/src/pages/vyond-go.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import VideoMuteButton from "../components/ui/VideoMuteButton.astro";
 import VyondNav from "../components/ui/VyondNav.astro";
 import { contactData } from "../data/contact";
@@ -8,7 +9,7 @@ import { base, r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Vyond Go en México — Crea videos con IA en segundos | TAEC"
+  title="Vyond Go en México | Videos con IA Rápidos | TAEC"
   description="Transforma texto, URLs o documentos en videos animados profesionales con Vyond Go. La forma más rápida de crear video corporativo con inteligencia artificial."
   section="Soluciones"
   page="vyond-go.html"

--- a/astro-web/src/pages/vyond-mobile.astro
+++ b/astro-web/src/pages/vyond-mobile.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import VideoMuteButton from "../components/ui/VideoMuteButton.astro";
 import VyondNav from "../components/ui/VyondNav.astro";
 import { contactData } from "../data/contact";
@@ -8,7 +9,7 @@ import { base, r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Vyond Mobile en México — Crea videos desde tu celular | TAEC"
+  title="Vyond Mobile en México | Video desde Celular | TAEC"
   description="Crea, edita y comparte videos corporativos desde tu dispositivo móvil con Vyond Mobile. Smart Capture con IA y acceso completo a Vyond Go en tu bolsillo."
   section="Soluciones"
   page="vyond-mobile.html"

--- a/astro-web/src/pages/vyond-professional.astro
+++ b/astro-web/src/pages/vyond-professional.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import VyondNav from "../components/ui/VyondNav.astro";
 import { contactData, getBookingUrl } from "../data/contact";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -7,7 +8,7 @@ import { base, r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Vyond Professional en México — Video corporativo para equipos L&D | TAEC"
+  title="Vyond Professional en México | Video Corporativo | TAEC"
   description="Escala la producción de video de capacitación con Vyond Professional. Colaboración de equipo, más créditos IA y soporte prioritario. Partner oficial en México."
   section="Soluciones"
   page="vyond-professional.html"

--- a/astro-web/src/pages/vyond-starter.astro
+++ b/astro-web/src/pages/vyond-starter.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import { contactData, getBookingUrl } from "../data/contact";
 import { vendors } from "../data/vendors";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -7,7 +8,7 @@ import { base, r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Vyond Starter en México — Crea videos animados con IA | TAEC"
+  title="Vyond Starter en México | Videos Animados IA | TAEC"
   description="Empieza a crear videos animados para capacitación con Vyond Starter. Acceso a Vyond Go (IA), Studio y plantillas profesionales. Partner oficial en México."
   section="Soluciones"
   page="vyond-starter.html"

--- a/astro-web/src/pages/vyond-studio.astro
+++ b/astro-web/src/pages/vyond-studio.astro
@@ -1,4 +1,5 @@
 ---
+// CHANGELOG: 2026-05-03 - Recortar título SEO a max 60 chars (Issue #216)
 import CtaFinal from "../components/ui/CtaFinal.astro";
 import VideoMuteButton from "../components/ui/VideoMuteButton.astro";
 import VyondNav from "../components/ui/VyondNav.astro";
@@ -9,7 +10,7 @@ import { base, r } from "../utils/paths";
 ---
 
 <BaseLayout 
-  title="Vyond Studio en México — Editor profesional de video animado | TAEC"
+  title="Vyond Studio en México | Video Animado | TAEC"
   description="Crea videos animados y mixed media con Vyond Studio. Traducción automática a 80+ idiomas, 1,100+ avatares IA y control creativo total. Partner oficial en México."
   section="Soluciones"
   page="vyond-studio.html"


### PR DESCRIPTION
Fixes #216. Trimmed 18 page titles across the site to be under 60 characters to avoid SERP truncation while maintaining the primary keywords and brand suffix. Added changelog entries.