### PR TITLE
fix: agregar campo 'to' en redirects 410 requerido por Netlify

### DIFF
--- a/astro-web/netlify.toml
+++ b/astro-web/netlify.toml
@@ -130,11 +130,13 @@
 
 [[redirects]]
   from = "/articulos/the-loneliness-o-ai"
+  to = "/gone"
   status = 410
   force = true
 
 [[redirects]]
   from = "/articulos/the-loneliness-of-ai"
+  to = "/gone"
   status = 410
   force = true
 


### PR DESCRIPTION
Netlify requiere el campo `to` en todos los redirects, incluso en status 410 (Gone). Sin él, el parser falla con "Missing to field" y el redirect se ignora.

## Cambio
Añadido `to = "/gone"` en los dos redirects 410 de `/articulos/the-loneliness-*` en `netlify.toml`.

## Error que resuelve
```
Could not parse redirect number 20: Missing "to" field
Could not parse redirect number 21: Missing "to" field
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)