### PR TITLE
fix(index): banner Summit → takeaway post-evento con UTM

### DIFF
--- a/astro-web/src/pages/index.astro
+++ b/astro-web/src/pages/index.astro
@@ -112,11 +112,11 @@ if (activePromos.length > 0) {
 
   <main id="main-content">
 
-    {/* BANNER ESTÁTICO DE EVENTO (Independiente de geolocalización) */}
+    {/* BANNER TAKEAWAY SUMMIT (post-evento mayo 2026) */}
     <div style="background:#1E3A8A; color:#FFFFFF; text-align:center; padding:12px 5%; font-size:14px; font-weight:700; width:100%; border-bottom:1px solid #1D4ED8;">
-      <span style="background:#2563EB; color:#FFF; padding:3px 10px; border-radius:12px; font-size:11px; margin-right:8px; vertical-align:middle; text-transform:uppercase;">📅 PRÓXIMO EVENTO</span>
-      <span style="vertical-align:middle; letter-spacing:0.3px;">Save the Date: 7 de mayo <span style="font-weight:500; opacity:0.9;">– El registro oficial y la agenda completa del evento ya se encuentran disponibles.</span></span>
-      <a href="https://www.articulate.com/events/mexico/" target="_blank" rel="noopener noreferrer" style="color:#93C5FD; text-decoration:underline; font-weight:700; margin-left:12px; vertical-align:middle; display:inline-block;">Saber más →</a>
+      <span style="background:#2563EB; color:#FFF; padding:3px 10px; border-radius:12px; font-size:11px; margin-right:8px; vertical-align:middle; text-transform:uppercase;">📅 SUMMIT CDMX</span>
+      <span style="vertical-align:middle; letter-spacing:0.3px;">¿Te perdiste el Corporate Learning Summit México? <span style="font-weight:500; opacity:0.9;">Accede a los materiales y conclusiones del evento.</span></span>
+      <a href="/contacto?ref=summit-2026" style="color:#93C5FD; text-decoration:underline; font-weight:700; margin-left:12px; vertical-align:middle; display:inline-block;">Solicitar materiales →</a>
     </div>
 
     <section class="triaje-hero">


### PR DESCRIPTION
## Qué cambia

El evento del 7 de mayo ya pasó. El banner "Save the Date" queda desactualizado y genera ruido.

Se reemplaza por un **takeaway post-evento** que convierte el interés residual en un lead inbound.

## Antes → Después

**Antes:** "Save the Date: 7 de mayo – El registro oficial y la agenda completa del evento ya se encuentran disponibles. → Saber más"

**Después:** "¿Te perdiste el Corporate Learning Summit México? Accede a los materiales y conclusiones del evento. → Solicitar materiales"

## Por qué contacto y no WhatsApp

- Registra el lead automáticamente en Zoho CRM
- UTM `?ref=summit-2026` permite trackear leads que vienen del banner
- El formulario califica al lead antes de que llegue a ventas

## Test plan

- [ ] Verificar que el banner se ve correctamente en mobile y desktop
- [ ] Verificar que el link lleva a `/contacto?ref=summit-2026`
- [ ] Verificar que el param `ref` llega al formulario de contacto