### PR TITLE
fix(seo/geo): corregir posicionamiento B2B — schema, content y metas de cursos

### DIFF
--- a/astro-web/src/content/cursos/crear-cursos-accesibles-con-articulate-360.md
+++ b/astro-web/src/content/cursos/crear-cursos-accesibles-con-articulate-360.md
@@ -3,7 +3,7 @@ titulo: "Crear cursos accesibles con Articulate 360"
 precio_usd: 580
 categoria: "Articulate 360"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Crear cursos accesibles con Articulate 360 con nuestros expertos certificados."
+descripcion: "Capacitación corporativa en accesibilidad para e-learning con Articulate 360. Estándares WCAG aplicados a la producción de cursos. Para equipos L&D."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/curso-articulate-360-avanzado.md
+++ b/astro-web/src/content/cursos/curso-articulate-360-avanzado.md
@@ -3,7 +3,7 @@ titulo: "Curso Articulate 360 Avanzado"
 precio_usd: 289
 categoria: "Articulate 360"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Curso Articulate 360 Avanzado con nuestros expertos certificados."
+descripcion: "Taller avanzado de Articulate 360 para diseñadores instruccionales con experiencia previa. Técnicas de producción profesional y publicación en LMS. En vivo."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/curso-articulate-360-b-sico.md
+++ b/astro-web/src/content/cursos/curso-articulate-360-b-sico.md
@@ -3,7 +3,7 @@ titulo: "Curso Articulate 360 Básico"
 precio_usd: 429
 categoria: "Articulate 360"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Curso Articulate 360 Básico con nuestros expertos certificados."
+descripcion: "Introducción a Articulate 360 para equipos de capacitación corporativa. Fundamentos de Storyline y Rise con instructor certificado. Taller en vivo."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/curso-articulate-360-completo.md
+++ b/astro-web/src/content/cursos/curso-articulate-360-completo.md
@@ -3,7 +3,7 @@ titulo: "Curso Articulate 360 Completo"
 precio_usd: 749
 categoria: "Articulate 360"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Curso Articulate 360 Completo con nuestros expertos certificados."
+descripcion: "Capacitación corporativa en Articulate 360 para equipos L&D: desde fundamentos hasta producción de cursos profesionales. Instructor certificado, modalidad en vivo."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/curso-articulate-rise-360.md
+++ b/astro-web/src/content/cursos/curso-articulate-rise-360.md
@@ -3,7 +3,7 @@ titulo: "Curso Articulate Rise 360+"
 precio_usd: 289
 categoria: "Articulate 360"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Curso Articulate Rise 360+ con nuestros expertos certificados."
+descripcion: "Capacitación corporativa en Articulate Rise 360 para equipos L&D. Producción de cursos responsive y modernos. Instructor certificado, en vivo."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/curso-articulate-storyline-experto.md
+++ b/astro-web/src/content/cursos/curso-articulate-storyline-experto.md
@@ -3,7 +3,7 @@ titulo: "Curso Articulate Storyline Experto"
 precio_usd: 599
 categoria: "Articulate 360"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Curso Articulate Storyline Experto con nuestros expertos certificados."
+descripcion: "Capacitación de nivel experto en Articulate Storyline para equipos L&D corporativos. Dominio completo de la herramienta para producción de cursos profesionales."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/curso-cerrado-articulate-con-ai-assistant.md
+++ b/astro-web/src/content/cursos/curso-cerrado-articulate-con-ai-assistant.md
@@ -3,7 +3,7 @@ titulo: "Curso Cerrado Articulate con AI Assistant"
 precio_usd: 3750
 categoria: "Articulate 360"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Curso Cerrado Articulate con AI Assistant con nuestros expertos certificados."
+descripcion: "Taller corporativo: Articulate 360 con AI Assistant para equipos L&D. Producción acelerada de cursos con inteligencia artificial integrada. En vivo."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/curso-dise-o-instruccional-de-guion-e-learning.md
+++ b/astro-web/src/content/cursos/curso-dise-o-instruccional-de-guion-e-learning.md
@@ -3,7 +3,7 @@ titulo: "Curso Diseño Instruccional de guion e-learning"
 precio_usd: 212
 categoria: "Diseño Instruccional"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Curso Diseño Instruccional de guion e-learning con nuestros expertos certificados."
+descripcion: "Taller de diseño instruccional y guionismo para equipos de capacitación corporativa. Metodologías ADDIE y SAM aplicadas a proyectos de e-learning empresarial."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/curso-storyline-360-t-cnicas-avanzadas.md
+++ b/astro-web/src/content/cursos/curso-storyline-360-t-cnicas-avanzadas.md
@@ -3,7 +3,7 @@ titulo: "Curso Storyline 360 Técnicas Avanzadas"
 precio_usd: 345
 categoria: "Articulate 360"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Curso Storyline 360 Técnicas Avanzadas con nuestros expertos certificados."
+descripcion: "Taller avanzado de Storyline 360 para diseñadores instruccionales corporativos. Interacciones complejas, variables y publicación SCORM. En vivo con instructor."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/desarrollo-de-paquete-de-actividades.md
+++ b/astro-web/src/content/cursos/desarrollo-de-paquete-de-actividades.md
@@ -3,7 +3,7 @@ titulo: "Desarrollo de paquete de actividades"
 precio_usd: 6027
 categoria: "DDC"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Desarrollo de paquete de actividades con nuestros expertos certificados."
+descripcion: "Taller corporativo de desarrollo de paquetes de actividades e-learning. Producción profesional bajo estándares SCORM/xAPI para empresas."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/lo-esencial-para-el-dise-o-de-e-learning.md
+++ b/astro-web/src/content/cursos/lo-esencial-para-el-dise-o-de-e-learning.md
@@ -3,7 +3,7 @@ titulo: "Lo esencial para el diseño de E-learning"
 precio_usd: 449
 categoria: "Diseño Instruccional"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Lo esencial para el diseño de E-learning con nuestros expertos certificados."
+descripcion: "Fundamentos de diseño de e-learning para equipos L&D corporativos. Bases metodológicas y buenas prácticas para producción de contenido de capacitación."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/moodle-administraci-n-y-creaci-n-de-cursos.md
+++ b/astro-web/src/content/cursos/moodle-administraci-n-y-creaci-n-de-cursos.md
@@ -3,7 +3,7 @@ titulo: "Moodle Administración y Creación de Cursos"
 precio_usd: 230
 categoria: "Moodle LMS"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Moodle Administración y Creación de Cursos con nuestros expertos certificados."
+descripcion: "Capacitación integral en Moodle para equipos IT y L&D corporativos: administración completa y creación de cursos. En vivo con instructor certificado."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/moodle-administraci-n.md
+++ b/astro-web/src/content/cursos/moodle-administraci-n.md
@@ -3,7 +3,7 @@ titulo: "Moodle Administración"
 precio_usd: 90
 categoria: "Moodle LMS"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Moodle Administración con nuestros expertos certificados."
+descripcion: "Capacitación técnica en administración de Moodle para equipos IT y L&D corporativos. Configuración, roles, plugins y reportes. Modalidad en vivo."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/moodle-creaci-n-de-cursos.md
+++ b/astro-web/src/content/cursos/moodle-creaci-n-de-cursos.md
@@ -3,7 +3,7 @@ titulo: "Moodle Creación de Cursos"
 precio_usd: 190
 categoria: "Moodle LMS"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Moodle Creación de Cursos con nuestros expertos certificados."
+descripcion: "Taller de creación de cursos en Moodle para instructores y diseñadores instruccionales corporativos. Actividades, evaluaciones y recursos. En vivo."
 ---
 ## Temario Completo
 

--- a/astro-web/src/content/cursos/vyond.md
+++ b/astro-web/src/content/cursos/vyond.md
@@ -3,7 +3,7 @@ titulo: "Vyond"
 precio_usd: 268
 categoria: "Vyond"
 portada: "/images/cursos/default.webp"
-descripcion: "Aprende y domina Vyond con nuestros expertos certificados."
+descripcion: "Taller de Vyond para equipos de diseño instruccional y comunicación corporativa. Producción de videos animados para capacitación empresarial. En vivo con instructor."
 ---
 ## Temario Completo
 

--- a/astro-web/src/layouts/BaseLayout.astro
+++ b/astro-web/src/layouts/BaseLayout.astro
@@ -103,8 +103,24 @@ const ogImageURL = new URL(
     "@context": "https://schema.org",
     "@type": "Organization",
     "name": "TAEC",
+    "legalName": "Training and eLearning Consulting",
+    "description": "Reseller autorizado de Articulate 360, Vyond y Totara en México. Servicios B2B: licenciamiento con factura CFDI, implementación de LMS, producción de cursos corporativos y capacitación técnica para equipos L&D.",
     "url": (Astro.site || 'https://nuevo.taec.com.mx').toString().replace(/\/$/, ''),
     "logo": new URL(`${base}assets/logo.svg`, Astro.site || 'https://nuevo.taec.com.mx').toString(),
+    "foundingDate": "2006",
+    "areaServed": ["MX", "CO", "CL", "PE", "AR"],
+    "knowsAbout": [
+      "Articulate 360",
+      "Learning Management Systems",
+      "Corporate eLearning",
+      "Instructional Design",
+      "Vyond",
+      "Totara LMS",
+      "Moodle"
+    ],
+    "sameAs": [
+      "https://www.linkedin.com/company/taec-mx"
+    ],
     "contactPoint": {
       "@type": "ContactPoint",
       "telephone": "+52-55-2775-8279",

--- a/astro-web/src/pages/curso-articulate.astro
+++ b/astro-web/src/pages/curso-articulate.astro
@@ -7,7 +7,7 @@ import { r } from "../utils/paths";
 
 <BaseLayout 
   title="Articulate 360 — Diseño de Cursos Interactivos | TAEC"
-  description="Aprende a crear cursos e-learning profesionales con Articulate 360. De cero a publicar en LMS en 2 días. Curso abierto virtual en vivo."
+  description="Capacitación corporativa en Articulate 360 para equipos L&D. Taller en vivo con instructor certificado: diseño, desarrollo y publicación en LMS. Modalidad abierta o cerrada para empresa."
   section="Capacitación"
   page="curso-articulate.html"
 >

--- a/astro-web/src/pages/curso-fundamentos.astro
+++ b/astro-web/src/pages/curso-fundamentos.astro
@@ -7,7 +7,7 @@ import { r } from "../utils/paths";
 
 <BaseLayout 
   title="Fundamentos del Diseño Instruccional y e-Learning | TAEC"
-  description="Aprende los principios esenciales para crear experiencias de aprendizaje corporativo efectivas, sin importar la herramienta que uses. Curso abierto virtual en vivo."
+  description="Taller de fundamentos de diseño instruccional para equipos L&D corporativos. Principios y metodologías para crear experiencias de aprendizaje efectivas. En vivo con instructor."
   section="Capacitación"
   page="curso-fundamentos.html"
 >

--- a/astro-web/src/pages/curso-moodle.astro
+++ b/astro-web/src/pages/curso-moodle.astro
@@ -7,7 +7,7 @@ import { r } from "../utils/paths";
 
 <BaseLayout 
   title="Moodle — Administración y Gestión de Cursos | TAEC"
-  description="Configura y administra tu plataforma Moodle desde cero: usuarios, cursos, actividades, calificaciones y reportes. Curso abierto virtual en vivo."
+  description="Capacitación técnica en Moodle para administradores y equipos L&D corporativos. Configuración completa: usuarios, roles, actividades, calificaciones y reportes. En vivo con instructor."
   section="Capacitación"
   page="curso-moodle.html"
 >

--- a/astro-web/src/pages/curso-storyline.astro
+++ b/astro-web/src/pages/curso-storyline.astro
@@ -7,7 +7,7 @@ import { r } from "../utils/paths";
 
 <BaseLayout 
   title="Storyline 360 Avanzado — Interactividad Compleja | TAEC"
-  description="Lleva tus cursos al siguiente nivel con lógica avanzada, simulaciones ramificadas y experiencias altamente personalizadas en Storyline 360."
+  description="Taller avanzado de Storyline 360 para equipos L&D corporativos. Interacciones complejas, simulaciones ramificadas y publicación SCORM/xAPI. En vivo con instructor certificado."
   section="Capacitación"
   page="curso-storyline.html"
 >

--- a/astro-web/src/pages/curso-vyond.astro
+++ b/astro-web/src/pages/curso-vyond.astro
@@ -7,7 +7,7 @@ import { r } from "../utils/paths";
 
 <BaseLayout 
   title="Vyond — Videos Animados para e-Learning | TAEC"
-  description="Crea videos explicativos y de microlearning con personajes animados profesionales. Sin experiencia en animación requerida. Curso abierto virtual en vivo."
+  description="Taller de Vyond para equipos de diseño instruccional y comunicación corporativa. Producción de videos animados para capacitación empresarial. En vivo con instructor certificado."
   section="Capacitación"
   page="curso-vyond.html"
 >


### PR DESCRIPTION
## Resumen

Elimina los vectores que hacen que motores de IA (ChatGPT, Perplexity, Gemini) confundan a TAEC con un marketplace de cursos B2C como Coursera o Udemy. Auditoría realizada el 2026-05-17.

## Cambios

### #247 — Organization schema enriquecido (`BaseLayout.astro`)
Añade `legalName`, `description`, `foundingDate`, `areaServed`, `knowsAbout` y `sameAs` al JSON-LD. Sin estos campos, los LLMs inferían el negocio del texto del sitio y lo categorizaban como proveedor de contenido.

### #248 — 15 content files de cursos (`src/content/cursos/*.md`)
Reemplaza el boilerplate `"Aprende y domina X con nuestros expertos certificados."` (idéntico al copy de Udemy) por framing corporativo B2B: `"Capacitación/Taller en X para equipos L&D corporativos..."`.

### #249 — Metas de 5 páginas de cursos
Elimina frases de learner individual ("Aprende a", "De cero a", "Sin experiencia requerida") en `curso-articulate`, `curso-moodle`, `curso-storyline`, `curso-vyond` y `curso-fundamentos`. Las páginas `curso-cerrado-empresa` y `curso-cerrado-grupos` ya tenían framing B2B correcto.

## Checklist

- [x] 21 archivos modificados, 0 cambios de lógica o estilos
- [x] Ninguna descripción contiene "Aprende y domina", "De cero a" ni "Sin experiencia requerida"
- [x] Organization schema válido (estructura JSON correcta)
- [x] `curso-cerrado-empresa` y `curso-cerrado-grupos` sin tocar (ya estaban bien)

Cierra #247, #248, #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)